### PR TITLE
Fix: Alerts & other Dialogs not working

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 80,
+    "endOfLine": "lf"
+}

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,30 +1,8 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
+include: package:flutter_lints/flutter.yaml
 
-include: package:lints/recommended.yaml
-
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
-
-# For additional information about configuring this file, see
-# https://dart.dev/guides/language/analysis-options
+linter:
+    rules:
+        # Always await, intentionally not await
+        unawaited_futures: true
+        prefer_single_quotes: true
+        invalid_dependency: false

--- a/lib/src/services/yust_alert_service.dart
+++ b/lib/src/services/yust_alert_service.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:universal_html/js.dart';
 
 import '../widgets/yust_select.dart';
 import '../widgets/yust_switch.dart';
 
 class YustAlertService {
-  final BuildContext context;
-  YustAlertService(this.context);
+  final GlobalKey<NavigatorState> navStateKey;
+  YustAlertService(this.navStateKey);
 
   Future<void> showAlert(String title, String message) {
+    final context = navStateKey.currentContext;
+    if (context == null) return Future.value();
     return showDialog<void>(
       context: context,
       builder: (BuildContext context) {
@@ -33,6 +36,8 @@ class YustAlertService {
     String cancelText = 'Abbrechen',
     String? description,
   }) {
+    final context = navStateKey.currentContext;
+    if (context == null) return Future.value();
     return showDialog<bool>(
       context: context,
       builder: (BuildContext context) {
@@ -70,6 +75,9 @@ class YustAlertService {
   }) {
     final controller = TextEditingController(text: initialText);
     final yustServiceValidationKey = GlobalKey<FormState>();
+
+    final context = navStateKey.currentContext;
+    if (context == null) return Future.value();
     return showDialog<String>(
       context: context,
       builder: (BuildContext context) {
@@ -120,6 +128,8 @@ class YustAlertService {
     required List<String> optionValues,
     String initialText = '',
   }) {
+    final context = navStateKey.currentContext;
+    if (context == null) return Future.value();
     return showDialog<String>(
       context: context,
       builder: (BuildContext context) {
@@ -164,6 +174,8 @@ class YustAlertService {
     String? actionName,
     required Widget Function({required void Function(T?) onChanged}) buildInner,
   }) {
+    final context = navStateKey.currentContext;
+    if (context == null) return Future.value();
     return showDialog<T?>(
       context: context,
       builder: (BuildContext context) {
@@ -274,6 +286,9 @@ class YustAlertService {
   }
 
   void showToast(String message) {
+    final context = navStateKey.currentContext;
+    if (context == null) return;
+
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text(message),
     ));

--- a/lib/src/util/yust_ui_helpers.dart
+++ b/lib/src/util/yust_ui_helpers.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class YustUiHelpers {
-  final BuildContext context;
-  YustUiHelpers(this.context);
+  final GlobalKey<NavigatorState> navStateKey;
+  YustUiHelpers(this.navStateKey);
 
   /// Under Firefox only one BroadcastStream can be used for the
   /// connectivity result. Therefore, use this stream instance
@@ -13,6 +13,8 @@ class YustUiHelpers {
 
   /// Does unfocus the current focus node.
   void unfocusCurrent() {
+    final context = navStateKey.currentContext;
+    if (context == null) return;
     final currentFocus = FocusScope.of(context);
     if (!currentFocus.hasPrimaryFocus) {
       currentFocus.unfocus();

--- a/lib/src/yust_ui.dart
+++ b/lib/src/yust_ui.dart
@@ -30,8 +30,8 @@ class YustUi {
     YustUi.imagePlaceholderPath = imagePlaceholderPath;
   }
 
-  static void initContext(BuildContext context) {
-    YustUi.alertService = YustAlertService(context);
-    YustUi.helpers = YustUiHelpers(context);
+  static void setNavStateKey(GlobalKey<NavigatorState> navStateKey) {
+    YustUi.alertService = YustAlertService(navStateKey);
+    YustUi.helpers = YustUiHelpers(navStateKey);
   }
 }


### PR DESCRIPTION
The BuildContext passed to `initContext` was one above the Navigator-Widget, therefore Dialogs could not be pushed ontop the NavStack. This PR changes YustAlertService to get the BuildContext of the Navigator by using a NavStateKey.

_Also this PR updates the prettierrc & analysis-options to align it with Univelop._