### PR TITLE
Fix: Empty YustPaginatedListView causes redscreen

### DIFF
--- a/lib/src/widgets/yust_paginated_list_view.dart
+++ b/lib/src/widgets/yust_paginated_list_view.dart
@@ -13,7 +13,7 @@ class YustPaginatedListView<T extends YustDoc> extends StatelessWidget {
   final ScrollController? scrollController;
   final Widget? header;
   final Widget? footer;
-  final Widget? emptyInfo;
+  final Widget emptyInfo;
 
   YustPaginatedListView({
     Key? key,
@@ -23,10 +23,11 @@ class YustPaginatedListView<T extends YustDoc> extends StatelessWidget {
     this.filters,
     this.hideItem,
     this.scrollController,
-    this.emptyInfo = const EmptyDisplay(),
+    Widget? emptyInfo,
     this.header,
     this.footer,
-  }) : super(key: key);
+  })  : this.emptyInfo = emptyInfo ?? const EmptyDisplay(),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +38,7 @@ class YustPaginatedListView<T extends YustDoc> extends StatelessWidget {
       scrollController: scrollController,
       header: header,
       footer: footer,
-      onEmpty: emptyInfo!,
+      onEmpty: emptyInfo,
       itemBuilderType: PaginateBuilderType.listView,
       itemBuilder: (context, documentSnapshot, index) =>
           _itemBuilder(index, context, documentSnapshot[index]),


### PR DESCRIPTION
A null value in `emptyInfo` had triggered a null-check and crash.