### PR TITLE
Fix: ImagePicker doesn't work under Firefox-Production

### DIFF
--- a/lib/src/util/yust_file_helpers.dart
+++ b/lib/src/util/yust_file_helpers.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'dart:typed_data';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +20,11 @@ import '../yust_ui.dart';
 
 class YustFileHelpers {
   YustFileHelpers();
+
+  /// Under Firefox only one BroadcastStream can be used for the
+  /// connectivity result. Therefore, use this stream instance
+  static final ConnectivityStream =
+      Connectivity().onConnectivityChanged.asBroadcastStream();
 
   /// Shares or downloads a file.
   /// On iOS and Android shows Share-Popup afterwards.

--- a/lib/src/util/yust_ui_helpers.dart
+++ b/lib/src/util/yust_ui_helpers.dart
@@ -6,11 +6,6 @@ class YustUiHelpers {
   final GlobalKey<NavigatorState> navStateKey;
   YustUiHelpers(this.navStateKey);
 
-  /// Under Firefox only one BroadcastStream can be used for the
-  /// connectivity result. Therefore, use this stream instance
-  final connectivityStream =
-      Connectivity().onConnectivityChanged.asBroadcastStream();
-
   /// Does unfocus the current focus node.
   void unfocusCurrent() {
     final context = navStateKey.currentContext;

--- a/lib/src/widgets/yust_image_picker.dart
+++ b/lib/src/widgets/yust_image_picker.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:yust/yust.dart';
+import 'package:yust_ui/yust_ui.dart';
 
 import '../screens/yust_image_screen.dart';
 import '../util/yust_file_handler.dart';
@@ -100,7 +101,7 @@ class YustImagePickerState extends State<YustImagePicker> {
     _enabled = widget.onChanged != null && !widget.readOnly;
     _fileHandler.newestFirst = widget.newestFirst;
     return StreamBuilder<ConnectivityResult>(
-      stream: YustUi.helpers.connectivityStream,
+      stream: YustFileHelpers.ConnectivityStream,
       builder: (context, snapshot) {
         if (snapshot.data != null) {
           _connectivityResult = snapshot.data!;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -296,7 +296,7 @@ packages:
     source: hosted
     version: "4.2.3"
   firebase_core:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
@@ -1174,10 +1174,10 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "4d47cef8a97a8b695241afaed641ece1fe6de749"
+      resolved-ref: becfe1ef04917768fd50167b0e3fdf1f9e900aa8
       url: "https://github.com/univelop/yust"
     source: git
-    version: "3.0.0"
+    version: "3.1.0"
 sdks:
   dart: ">=2.17.5 <3.0.0"
   flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 dependencies:
     flutter:
         sdk: flutter
-    yust: ^3.1.0
-    # yust:
-    #   git:
-    #     url: https://github.com/univelop/yust
-    #     ref: master
+    # yust: ^3.1.0
+    yust:
+        git:
+            url: https://github.com/univelop/yust
+            ref: master
     # yust:
     #   path: ../yust
     firebase_core: ^1.20.1


### PR DESCRIPTION
This moves the `ConnectivityStream` to the YustFileHelper (because it's already exported & can be accessed staticly)