### PR TITLE
Fix: Focus Issues with YustText-/NumberField

### DIFF
--- a/lib/src/widgets/yust_number_field.dart
+++ b/lib/src/widgets/yust_number_field.dart
@@ -81,6 +81,7 @@ class YustNumberField extends StatelessWidget {
       enabled: enabled,
       autovalidateMode:
           validator != null ? AutovalidateMode.onUserInteraction : null,
+      focusNode: focusNode,
       autofocus: autofocus,
       hideKeyboardOnAutofocus: hideKeyboardOnAutofocus,
       validator:

--- a/lib/src/widgets/yust_number_field.dart
+++ b/lib/src/widgets/yust_number_field.dart
@@ -47,7 +47,7 @@ class YustNumberField extends StatelessWidget {
     this.suffixIcon,
     this.focusNode,
     this.autofocus = false,
-    this.hideKeyboardOnAutofocus = true,
+    this.hideKeyboardOnAutofocus = false,
     this.validator,
     this.divider = true,
   }) : super(key: key);

--- a/lib/src/widgets/yust_text_field.dart
+++ b/lib/src/widgets/yust_text_field.dart
@@ -55,7 +55,7 @@ class YustTextField extends StatefulWidget {
     this.readOnly = false,
     this.obscureText = false,
     this.autofocus = false,
-    this.hideKeyboardOnAutofocus = true,
+    this.hideKeyboardOnAutofocus = false,
     this.focusNode,
     this.style = YustInputStyle.normal,
     this.divider = true,
@@ -117,7 +117,7 @@ class _YustTextFieldState extends State<YustTextField> {
         }
       }
     });
-    if (widget.hideKeyboardOnAutofocus) {
+    if (widget.autofocus && widget.hideKeyboardOnAutofocus) {
       Future.delayed(
         const Duration(),
         () => SystemChannels.textInput.invokeMethod('TextInput.hide'),


### PR DESCRIPTION
This PR fixes two issues:
1. The `focusNode` of the `YustNumberField` is not passed down to the inner `YustTextField`
2. The `hideKeyboardOnAutofocus` is `true` per default. This causes any TextField to hide the keyboard on inital render. Esp. with `autofocus: true` the user can't enter values directly.
(Even on Web the keyboard dismissal causes the cursor to be rendered correctly, but the user needs to click in the field to really enter values)