### PR TITLE
Fix: Use `getCurrentUserId` instead of `Yust.authService.currUserId`

### DIFF
--- a/lib/src/screens/yust_account_edit_screen.dart
+++ b/lib/src/screens/yust_account_edit_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
-import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:yust/yust.dart';
 
 import '../widgets/yust_doc_builder.dart';
@@ -27,7 +27,7 @@ class YustAccountEditScreen extends StatelessWidget {
         appBar: AppBar(title: const Text('Persönliche Daten')),
         body: YustDocBuilder<YustUser>(
             modelSetup: Yust.userSetup,
-            id: Yust.authService.currUserId,
+            id: Yust.authService.getCurrentUserId(),
             builder: (user, insights, context) {
               if (user == null) {
                 return const Center(

--- a/lib/src/screens/yust_account_screen.dart
+++ b/lib/src/screens/yust_account_screen.dart
@@ -14,7 +14,7 @@ class YustAccountScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return YustDocBuilder<YustUser>(
       modelSetup: Yust.userSetup,
-      id: Yust.authService.currUserId,
+      id: Yust.authService.getCurrentUserId(),
       builder: (user, insights, context) {
         if (user == null) {
           return const Scaffold(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1188,9 +1188,11 @@ packages:
   yust:
     dependency: "direct main"
     description:
-      path: "../yust"
-      relative: true
-    source: path
+      path: "."
+      ref: master
+      resolved-ref: "9d3b95b7ee7fdd0c41223b805bc9296d0e5b510f"
+      url: "https://github.com/univelop/yust.git"
+    source: git
     version: "3.2.0"
 sdks:
   dart: ">=2.17.5 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     yust:
         git:
             url: https://github.com/univelop/yust.git
-            ref: feature/refactor-docSetup
+            ref: master
     firebase_core: ^1.20.1
     firebase_storage: ^10.3.5
     firebase_storage_mocks: ^0.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     yust:
         git:
             url: https://github.com/univelop/yust.git
-            ref: master
+            ref: feature/refactor-docSetup
     firebase_core: ^1.20.1
     firebase_storage: ^10.3.5
     firebase_storage_mocks: ^0.5.1


### PR DESCRIPTION
Because `Yust.authService.currUserId` is removed [in this Yust-PR](https://d51.tech/ylvt) we need to use the new function.