### PR TITLE
Fix: Replace open_file-package with open_filex-package

### DIFF
--- a/lib/src/util/yust_file_handler.dart
+++ b/lib/src/util/yust_file_handler.dart
@@ -10,7 +10,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
-import 'package:open_file/open_file.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -259,7 +259,7 @@ class YustFileHandler {
           await Dio().download(yustFile.url!, filePath);
           await EasyLoading.dismiss();
         }
-        var result = await OpenFile.open(filePath);
+        var result = await OpenFilex.open(filePath);
         if (result.type != ResultType.done) {
           await _launchBrowser(yustFile);
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -646,15 +646,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
-  open_file:
+  open_filex:
     dependency: "direct main"
     description:
-      path: "."
-      ref: master
-      resolved-ref: fbf68e4bb5cb3e262d8f8ebe10b2f8449ff8e030
-      url: "https://github.com/crazecoder/open_file.git"
-    source: git
-    version: "3.2.2"
+      name: open_filex
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
     universal_html: ^2.0.8
     mime: ^1.0.0
     connectivity_plus: ^1.0.6
-    open_file: ^3.2.1
     url_launcher: ^6.1.2
     crypto: ^3.0.1
     collection: ^1.16.0
@@ -43,13 +42,8 @@ dependencies:
     image_picker: ^0.8.4
     paginate_firestore: ^1.0.3+1
     mask_text_input_formatter: ^2.0.0
+    open_filex: ^4.3.1
 
 dev_dependencies:
     flutter_lints: ^2.0.1
     test: ^1.16.0
-
-dependency_overrides:
-    open_file:
-        git:
-            url: https://github.com/crazecoder/open_file.git
-            ref: master


### PR DESCRIPTION
Because `open_file` is not very well maintained, we switch to the fork `open_filex`