### PR TITLE
Add new single image view for yust image picker

### DIFF
--- a/lib/src/widgets/yust_file_picker.dart
+++ b/lib/src/widgets/yust_file_picker.dart
@@ -43,6 +43,8 @@ class YustFilePicker extends StatefulWidget {
 
   final List<String>? allowedExtensions;
 
+  final bool allowOnlyImages;
+
   const YustFilePicker({
     Key? key,
     this.label,
@@ -58,6 +60,7 @@ class YustFilePicker extends StatefulWidget {
     this.allowMultiple = true,
     this.allowedExtensions,
     this.divider = true,
+    this. allowOnlyImages = false,
   }) : super(key: key);
 
   @override
@@ -303,8 +306,9 @@ class YustFilePickerState extends State<YustFilePicker> {
 
   Future<void> _pickFiles() async {
     YustUi.helpers.unfocusCurrent();
+    final type = (widget.allowedExtensions != null) ? FileType.custom : (widget.allowOnlyImages ? FileType.image: FileType.any);
     final result = await FilePicker.platform.pickFiles(
-      type: (widget.allowedExtensions != null) ? FileType.custom : FileType.any,
+      type: type,
       allowedExtensions:
           (widget.allowedExtensions != null) ? widget.allowedExtensions : null,
       allowMultiple: widget.allowMultiple,

--- a/lib/src/widgets/yust_image_picker.dart
+++ b/lib/src/widgets/yust_image_picker.dart
@@ -38,7 +38,7 @@ class YustImagePicker extends StatefulWidget {
   final bool readOnly;
   final String yustQuality;
   final bool divider;
-  final bool originalView;
+  final bool showCentered;
 
   /// default is 15
   final int imageCount;
@@ -58,7 +58,7 @@ class YustImagePicker extends StatefulWidget {
     this.newestFirst = false,
     this.yustQuality = 'medium',
     this.divider = true,
-    this.originalView = false,
+    this.showCentered = false,
     int? imageCount,
   })  : imageCount = imageCount ?? 15,
         super(key: key);
@@ -236,7 +236,7 @@ class YustImagePickerState extends State<YustImagePicker> {
         ),
       );
     } else {
-      if (widget.originalView) {
+      if (widget.showCentered) {
         return Container(
           constraints: const BoxConstraints(
             minHeight: 100,

--- a/lib/src/widgets/yust_image_picker.dart
+++ b/lib/src/widgets/yust_image_picker.dart
@@ -38,6 +38,7 @@ class YustImagePicker extends StatefulWidget {
   final bool readOnly;
   final String yustQuality;
   final bool divider;
+  final bool originalView;
 
   /// default is 15
   final int imageCount;
@@ -57,6 +58,7 @@ class YustImagePicker extends StatefulWidget {
     this.newestFirst = false,
     this.yustQuality = 'medium',
     this.divider = true,
+    this.originalView = false,
     int? imageCount,
   })  : imageCount = imageCount ?? 15,
         super(key: key);
@@ -234,7 +236,20 @@ class YustImagePickerState extends State<YustImagePicker> {
         ),
       );
     } else {
-      return Container(
+      if (widget.originalView) {
+        return Container(
+          constraints: const BoxConstraints(
+            minHeight: 100,
+          ),
+          child: file.url != null
+                  ? Hero(
+                      tag: file.url!,
+                      child: preview,
+                    )
+                  : preview,
+                  );
+                } else {
+         return Container(
           constraints: const BoxConstraints(
             minHeight: 100,
           ),
@@ -253,6 +268,8 @@ class YustImagePickerState extends State<YustImagePicker> {
                   : preview,
             ),
           ));
+      }
+     
     }
   }
 


### PR DESCRIPTION
Gives the FilePicker an option so that the dialog only allows Images as files.
Extends the YustImagePicker with one new attribute for displaying single images true to size.