### PR TITLE
Yust image screen turn off sharing

### DIFF
--- a/lib/src/screens/yust_image_screen.dart
+++ b/lib/src/screens/yust_image_screen.dart
@@ -74,24 +74,6 @@ class _YustImageScreenState extends State<YustImageScreen> {
     super.initState();
   }
 
-  Widget _buildScalableImage(ImageProvider<Object> imageProvider) {
-    return Image(
-      image: imageProvider,
-      fit: BoxFit.scaleDown,
-      loadingBuilder: (BuildContext context, Widget child,
-          ImageChunkEvent? loadingProgress) {
-        if (loadingProgress == null) return child;
-        return const Center(
-          child: SizedBox(
-            width: 20.0,
-            height: 20.0,
-            child: CircularProgressIndicator(),
-          ),
-        );
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -248,6 +230,24 @@ class _YustImageScreenState extends State<YustImageScreen> {
           PhotoViewHeroAttributes(tag: widget.images[index].url ?? ''),
       onTapUp: (context, details, controllerValue) {
         Navigator.pop(context);
+      },
+    );
+  }
+
+  Widget _buildScalableImage(ImageProvider<Object> imageProvider) {
+    return Image(
+      image: imageProvider,
+      fit: BoxFit.scaleDown,
+      loadingBuilder: (BuildContext context, Widget child,
+          ImageChunkEvent? loadingProgress) {
+        if (loadingProgress == null) return child;
+        return const Center(
+          child: SizedBox(
+            width: 20.0,
+            height: 20.0,
+            child: CircularProgressIndicator(),
+          ),
+        );
       },
     );
   }

--- a/lib/src/screens/yust_image_screen.dart
+++ b/lib/src/screens/yust_image_screen.dart
@@ -14,19 +14,22 @@ class YustImageScreen extends StatefulWidget {
   final List<YustImage> images;
 
   final int activeImageIndex;
-  final void Function(YustImage image, Uint8List newImage) onSave;
+  final void Function(YustImage image, Uint8List newImage)? onSave;
 
   /// Indicates whether drawing is allowed on the image.
   ///
   /// This feature is only available on mobile and desktop apps.
   final bool allowDrawing;
 
+  final bool allowShare;
+
   const YustImageScreen({
     super.key,
     required this.images,
-    required this.onSave,
+    this.onSave,
     this.activeImageIndex = 0,
     this.allowDrawing = false,
+    this.allowShare = true,
   });
 
   static void navigateToScreen({
@@ -34,7 +37,8 @@ class YustImageScreen extends StatefulWidget {
     required List<YustImage> images,
     int activeImageIndex = 0,
     bool allowDrawing = false,
-    required void Function(YustImage image, Uint8List newImage) onSave,
+    bool allowShare = true,
+    void Function(YustImage image, Uint8List newImage)? onSave,
   }) {
     unawaited(
       Navigator.of(context).push(MaterialPageRoute<void>(
@@ -43,6 +47,7 @@ class YustImageScreen extends StatefulWidget {
           onSave: onSave,
           activeImageIndex: activeImageIndex,
           allowDrawing: allowDrawing,
+          allowShare: allowShare,
         ),
       )),
     );
@@ -91,9 +96,10 @@ class _YustImageScreenState extends State<YustImageScreen> {
           ),
         ),
       ),
-      if (!kIsWeb && widget.allowDrawing) _buildDrawButton(context, image),
+      if (!kIsWeb && widget.allowDrawing && widget.onSave != null)
+        _buildDrawButton(context, image),
       if (kIsWeb) _buildCloseButton(context),
-      _buildShareButton(context, image),
+      if (widget.allowShare) _buildShareButton(context, image),
     ]);
   }
 
@@ -170,10 +176,11 @@ class _YustImageScreenState extends State<YustImageScreen> {
               ),
             ),
           ),
-        if (!kIsWeb && widget.allowDrawing)
+        if (!kIsWeb && widget.allowDrawing && widget.onSave != null)
           _buildDrawButton(context, widget.images[activeImageIndex]),
         if (kIsWeb) _buildCloseButton(context),
-        _buildShareButton(context, widget.images[activeImageIndex]),
+        if (widget.allowShare)
+          _buildShareButton(context, widget.images[activeImageIndex]),
       ],
     );
   }
@@ -202,7 +209,7 @@ class _YustImageScreenState extends State<YustImageScreen> {
                         image: _getImageOfUrl(image),
                         onSave: (imageBytes) async {
                           if (imageBytes != null) {
-                            widget.onSave(image, imageBytes);
+                            widget.onSave!(image, imageBytes);
                             setState(() {});
                           }
                         });


### PR DESCRIPTION
Univelop issue: [5556](https://github.com/univelop/univelop/issues/5556)

Adapt yust image screen to display store images as well without changing the original image screen.