### PR TITLE
Add YustFileTapMode enum for file picker tap behavior

### DIFF
--- a/lib/src/generated/locale_keys.g.dart
+++ b/lib/src/generated/locale_keys.g.dart
@@ -2,7 +2,6 @@
 
 abstract class LocaleKeys {
   static const abortCondition = 'abortCondition';
-  static const abortOnError = 'abortOnError';
   static const abortWorkflow = 'abortWorkflow';
   static const aborted = 'aborted';
   static const abortingBecauseStartedWorkflowCrashed =
@@ -32,19 +31,15 @@ abstract class LocaleKeys {
   static const actionDefinitionExplanation = 'actionDefinitionExplanation';
   static const actionType = 'actionType';
   static const active = 'active';
-  static const activeInvitationLinks = 'activeInvitationLinks';
   static const activeRole = 'activeRole';
   static const activity = 'activity';
   static const add = 'add';
-  static const addActionButton = 'addActionButton';
   static const addAndDone = 'addAndDone';
   static const addAnyways = 'addAnyways';
-  static const addComponent = 'addComponent';
-  static const addDaysDatesDescription = 'addDaysDatesDescription';
+  static const addBillingAdmin = 'addBillingAdmin';
   static const addDaysDescription = 'addDaysDescription';
   static const addEntry = 'addEntry';
   static const addFrequentlyUsedActions = 'addFrequentlyUsedActions';
-  static const addHoursDatesDescription = 'addHoursDatesDescription';
   static const addHoursDescription = 'addHoursDescription';
   static const addIntegration = 'addIntegration';
   static const addItem = 'addItem';
@@ -57,6 +52,7 @@ abstract class LocaleKeys {
   static const addOption = 'addOption';
   static const addPath = 'addPath';
   static const addRole = 'addRole';
+  static const addSecondsDescription = 'addSecondsDescription';
   static const addSendingTime = 'addSendingTime';
   static const addStatus = 'addStatus';
   static const addToListDescription = 'addToListDescription';
@@ -66,7 +62,6 @@ abstract class LocaleKeys {
   static const addUserToCc = 'addUserToCc';
   static const addValue = 'addValue';
   static const addWeeksDescription = 'addWeeksDescription';
-  static const addWorkflow = 'addWorkflow';
   static const addWorkspace = 'addWorkspace';
   static const addXmlFile = 'addXmlFile';
   static const addXmlFileLong = 'addXmlFileLong';
@@ -74,7 +69,6 @@ abstract class LocaleKeys {
   static const addedRecord = 'addedRecord';
   static const addingElementToSlotWithInteractiveNotPossible =
       'addingElementToSlotWithInteractiveNotPossible';
-  static const addingImage = 'addingImage';
   static const addingImages = 'addingImages';
   static const addingInteractiveItemToFilledSlotNotPossible =
       'addingInteractiveItemToFilledSlotNotPossible';
@@ -85,12 +79,14 @@ abstract class LocaleKeys {
       'addingMemberToPortalPleaseRefresh';
   static const addingTilesExplanation = 'addingTilesExplanation';
   static const additionalQuantityBrick = 'additionalQuantityBrick';
+  static const additionalRecipients = 'additionalRecipients';
+  static const additionalRecipientsExplanation =
+      'additionalRecipientsExplanation';
   static const additionalScannerBrick = 'additionalScannerBrick';
   static const additionalWriteFilters = 'additionalWriteFilters';
   static const address = 'address';
   static const addressBrick = 'addressBrick';
   static const addressBrickDescription = 'addressBrickDescription';
-  static const addressLine = 'addressLine';
   static const addressValueImportError = 'addressValueImportError';
   static const adjust = 'adjust';
   static const adjustPosition = 'adjustPosition';
@@ -119,13 +115,14 @@ abstract class LocaleKeys {
   static const aiAgentSetupError = 'aiAgentSetupError';
   static const aiAgentStep = 'aiAgentStep';
   static const aiAgentStepDescription = 'aiAgentStepDescription';
+  static const aiAgentStepVariableExplanation =
+      'aiAgentStepVariableExplanation';
   static const aiAgentTaskFailedEmailBody = 'aiAgentTaskFailedEmailBody';
   static const aiAgentTaskFailedMessage = 'aiAgentTaskFailedMessage';
   static const aiAgentTaskFailedPreheader = 'aiAgentTaskFailedPreheader';
   static const aiAgentTaskFailedSubject = 'aiAgentTaskFailedSubject';
   static const aiAgentTileSpecNotFound = 'aiAgentTileSpecNotFound';
   static const aiAgentTitle = 'aiAgentTitle';
-  static const aiAgentUndefinedMessage = 'aiAgentUndefinedMessage';
   static const aiBuilderAgent = 'aiBuilderAgent';
   static const aiBuilderAgentBeta = 'aiBuilderAgentBeta';
   static const aiBuilderAgentConnectionExplanation =
@@ -133,6 +130,8 @@ abstract class LocaleKeys {
   static const aiBuilderAgentExamplePrompt1 = 'aiBuilderAgentExamplePrompt1';
   static const aiBuilderAgentExamplePrompt2 = 'aiBuilderAgentExamplePrompt2';
   static const aiBuilderAgentIntegration = 'aiBuilderAgentIntegration';
+  static const aiBuilderAgentIntegrationNotSet =
+      'aiBuilderAgentIntegrationNotSet';
   static const aiBuilderAgentOnlyTestWorkspace =
       'aiBuilderAgentOnlyTestWorkspace';
   static const aiBuilderAgentOnlyTestWorkspaceExplanation =
@@ -142,6 +141,8 @@ abstract class LocaleKeys {
   static const aiDescription = 'aiDescription';
   static const aiDescriptionHelperInfo = 'aiDescriptionHelperInfo';
   static const aiExpressionGenerationError = 'aiExpressionGenerationError';
+  static const aiImageRecognition = 'aiImageRecognition';
+  static const aiSpeechRecognition = 'aiSpeechRecognition';
   static const aiTileDescriptionExample = 'aiTileDescriptionExample';
   static const aiTileNameExample = 'aiTileNameExample';
   static const alertAbortImport = 'alertAbortImport';
@@ -162,7 +163,6 @@ abstract class LocaleKeys {
   static const alertCannotBulkDeleteMembers = 'alertCannotBulkDeleteMembers';
   static const alertCannotChangeIntegrationTypeBecauseOfReferences =
       'alertCannotChangeIntegrationTypeBecauseOfReferences';
-  static const alertCannotChangeLicense = 'alertCannotChangeLicense';
   static const alertCannotChangeLink = 'alertCannotChangeLink';
   static const alertCannotChangeOwner = 'alertCannotChangeOwner';
   static const alertCannotChangeSelectionMode =
@@ -180,8 +180,6 @@ abstract class LocaleKeys {
       'alertCannotDeleteAnySelectedRecord';
   static const alertCannotDeleteBrickWithReferences =
       'alertCannotDeleteBrickWithReferences';
-  static const alertCannotDeleteBrickWithRoleReferences =
-      'alertCannotDeleteBrickWithRoleReferences';
   static const alertCannotDeleteFile = 'alertCannotDeleteFile';
   static const alertCannotDeleteFlowStep = 'alertCannotDeleteFlowStep';
   static const alertCannotDeleteFolder = 'alertCannotDeleteFolder';
@@ -191,8 +189,6 @@ abstract class LocaleKeys {
   static const alertCannotDeleteLabelWithReferences =
       'alertCannotDeleteLabelWithReferences';
   static const alertCannotDeleteLastTab = 'alertCannotDeleteLastTab';
-  static const alertCannotDeleteListReferencedBricks =
-      'alertCannotDeleteListReferencedBricks';
   static const alertCannotDeleteLockedBrick = 'alertCannotDeleteLockedBrick';
   static const alertCannotDeleteLockedRecord = 'alertCannotDeleteLockedRecord';
   static const alertCannotDeleteLockedRecords =
@@ -208,7 +204,6 @@ abstract class LocaleKeys {
   static const alertCannotDeleteWorkspace = 'alertCannotDeleteWorkspace';
   static const alertCannotDisableTabs = 'alertCannotDisableTabs';
   static const alertCannotDownloadFile = 'alertCannotDownloadFile';
-  static const alertCannotDownloadTemplate = 'alertCannotDownloadTemplate';
   static const alertCannotDuplicateLockedBrick =
       'alertCannotDuplicateLockedBrick';
   static const alertCannotEditAnySelectedRecord =
@@ -223,8 +218,6 @@ abstract class LocaleKeys {
       'alertCannotLockRecordMandatoryFieldStatus';
   static const alertCannotOpenFile = 'alertCannotOpenFile';
   static const alertCannotOpenFileWithError = 'alertCannotOpenFileWithError';
-  static const alertCannotProcessDocument = 'alertCannotProcessDocument';
-  static const alertCannotRecalculateLists = 'alertCannotRecalculateLists';
   static const alertCannotRecalculateTiles = 'alertCannotRecalculateTiles';
   static const alertCannotRemoveOwner = 'alertCannotRemoveOwner';
   static const alertCannotResetIntegrationSettingsBecauseOfReferences =
@@ -267,7 +260,6 @@ abstract class LocaleKeys {
   static const alertChangedEmail = 'alertChangedEmail';
   static const alertChangedPassword = 'alertChangedPassword';
   static const alertCheckFields = 'alertCheckFields';
-  static const alertComingSoon = 'alertComingSoon';
   static const alertConfirmChangeIntegrationType =
       'alertConfirmChangeIntegrationType';
   static const alertConfirmDeactivateSyncUserRoles =
@@ -275,8 +267,6 @@ abstract class LocaleKeys {
   static const alertConfirmDeleteIntegration = 'alertConfirmDeleteIntegration';
   static const alertConfirmDeleteSelectedFiles =
       'alertConfirmDeleteSelectedFiles';
-  static const alertConfirmDeleteSelectedImages =
-      'alertConfirmDeleteSelectedImages';
   static const alertConfirmDeleteUserByEmail = 'alertConfirmDeleteUserByEmail';
   static const alertConfirmDeleteUserByPassword =
       'alertConfirmDeleteUserByPassword';
@@ -288,9 +278,6 @@ abstract class LocaleKeys {
   static const alertConfirmSignOut = 'alertConfirmSignOut';
   static const alertConnectionTestFailed = 'alertConnectionTestFailed';
   static const alertCreateFormTile = 'alertCreateFormTile';
-  static const alertCreateMemberTile = 'alertCreateMemberTile';
-  static const alertCreateMemberTileFromExistingRecords =
-      'alertCreateMemberTileFromExistingRecords';
   static const alertCreatedTile = 'alertCreatedTile';
   static const alertCreatedUser = 'alertCreatedUser';
   static const alertCreatingRows = 'alertCreatingRows';
@@ -311,7 +298,6 @@ abstract class LocaleKeys {
   static const alertDirectoryNotSet = 'alertDirectoryNotSet';
   static const alertDiscardUnsavedChanges = 'alertDiscardUnsavedChanges';
   static const alertDocumentAlreadyExisting = 'alertDocumentAlreadyExisting';
-  static const alertDuplicatesFound = 'alertDuplicatesFound';
   static const alertEditFilterMissingPermissions =
       'alertEditFilterMissingPermissions';
   static const alertEditWorkflow = 'alertEditWorkflow';
@@ -344,7 +330,6 @@ abstract class LocaleKeys {
   static const alertFileRename = 'alertFileRename';
   static const alertFileTooBig = 'alertFileTooBig';
   static const alertFilteredList = 'alertFilteredList';
-  static const alertFlowException = 'alertFlowException';
   static const alertFlowSpecNotFound = 'alertFlowSpecNotFound';
   static const alertFlowSpecNotFoundOrOutdated =
       'alertFlowSpecNotFoundOrOutdated';
@@ -369,7 +354,6 @@ abstract class LocaleKeys {
       'alertKanbanStatusBrickNotAvailable';
   static const alertLeaveWorkspace = 'alertLeaveWorkspace';
   static const alertLinkNotSupported = 'alertLinkNotSupported';
-  static const alertLinkingOfRecords = 'alertLinkingOfRecords';
   static const alertListName = 'alertListName';
   static const alertLocalFile = 'alertLocalFile';
   static const alertLocalImage = 'alertLocalImage';
@@ -380,8 +364,6 @@ abstract class LocaleKeys {
   static const alertLockingRecord = 'alertLockingRecord';
   static const alertMaxNumberFiles = 'alertMaxNumberFiles';
   static const alertMaxOneFile = 'alertMaxOneFile';
-  static const alertMemberListGlobal = 'alertMemberListGlobal';
-  static const alertMemberListUnique = 'alertMemberListUnique';
   static const alertMissingBackgroundImage = 'alertMissingBackgroundImage';
   static const alertMissingConnection = 'alertMissingConnection';
   static const alertMissingConnectionAddImages =
@@ -389,17 +371,14 @@ abstract class LocaleKeys {
   static const alertMissingConnectionDrawing = 'alertMissingConnectionDrawing';
   static const alertMissingConnectionPrintOut =
       'alertMissingConnectionPrintOut';
-  static const alertMissingDirectory = 'alertMissingDirectory';
   static const alertMissingMemberTile = 'alertMissingMemberTile';
   static const alertMissingNewPassword = 'alertMissingNewPassword';
   static const alertMissingOldPassword = 'alertMissingOldPassword';
   static const alertMissingPermissionMicrophone =
       'alertMissingPermissionMicrophone';
-  static const alertMissingSheet = 'alertMissingSheet';
   static const alertMissingSignature = 'alertMissingSignature';
   static const alertMissingSignatureName = 'alertMissingSignatureName';
   static const alertMissingTechName = 'alertMissingTechName';
-  static const alertMissingUserPickerBrick = 'alertMissingUserPickerBrick';
   static const alertMissingWritePermission = 'alertMissingWritePermission';
   static const alertMoreThanOneResult = 'alertMoreThanOneResult';
   static const alertMoveTileToFolder = 'alertMoveTileToFolder';
@@ -419,7 +398,6 @@ abstract class LocaleKeys {
   static const alertOriginBrick = 'alertOriginBrick';
   static const alertOtherBelongsToBricksExists =
       'alertOtherBelongsToBricksExists';
-  static const alertPageAlreadyOpen = 'alertPageAlreadyOpen';
   static const alertPrivateTile = 'alertPrivateTile';
   static const alertQueryFailed = 'alertQueryFailed';
   static const alertReachedLimitNumberBricks = 'alertReachedLimitNumberBricks';
@@ -431,8 +409,6 @@ abstract class LocaleKeys {
   static const alertRemoveUserFirst = 'alertRemoveUserFirst';
   static const alertRemovedInvalidRoleConfigurations =
       'alertRemovedInvalidRoleConfigurations';
-  static const alertRequestError = 'alertRequestError';
-  static const alertRequiredBricks = 'alertRequiredBricks';
   static const alertResendEmailVerificationTooFast =
       'alertResendEmailVerificationTooFast';
   static const alertResendMailVerification = 'alertResendMailVerification';
@@ -454,7 +430,6 @@ abstract class LocaleKeys {
   static const alertSettingsTileNotFound = 'alertSettingsTileNotFound';
   static const alertShareList = 'alertShareList';
   static const alertSingleOptionImportError = 'alertSingleOptionImportError';
-  static const alertSolutionFolder = 'alertSolutionFolder';
   static const alertStartWorkflow = 'alertStartWorkflow';
   static const alertStopSharing = 'alertStopSharing';
   static const alertStopSharingWithWorkspace = 'alertStopSharingWithWorkspace';
@@ -463,13 +438,9 @@ abstract class LocaleKeys {
   static const alertTechnicalNameNotSet = 'alertTechnicalNameNotSet';
   static const alertTooManyFavorites = 'alertTooManyFavorites';
   static const alertTooManyRecords = 'alertTooManyRecords';
-  static const alertTransferExistingData = 'alertTransferExistingData';
-  static const alertTransferExistingDataExplanation =
-      'alertTransferExistingDataExplanation';
   static const alertTransferKeepSynced = 'alertTransferKeepSynced';
   static const alertUnknownContent = 'alertUnknownContent';
   static const alertUnlockRecord = 'alertUnlockRecord';
-  static const alertUnprocessedPositions = 'alertUnprocessedPositions';
   static const alertUnsupportedLink = 'alertUnsupportedLink';
   static const alertUrl = 'alertUrl';
   static const alertWebTileName = 'alertWebTileName';
@@ -482,7 +453,6 @@ abstract class LocaleKeys {
       'alertWorkflowErrorInStepWithTechName';
   static const alertWorkflowErrorWithMessage = 'alertWorkflowErrorWithMessage';
   static const alertWorkflowName = 'alertWorkflowName';
-  static const alertWorkflowNotStarted = 'alertWorkflowNotStarted';
   static const alertWorkflowPaused = 'alertWorkflowPaused';
   static const alertWorkflowStartedOnServer = 'alertWorkflowStartedOnServer';
   static const alertWorkspaceId = 'alertWorkspaceId';
@@ -492,10 +462,10 @@ abstract class LocaleKeys {
   static const all = 'all';
   static const allDayEvent = 'allDayEvent';
   static const allDone = 'allDone';
+  static const allEnabledRoles = 'allEnabledRoles';
   static const allOrNone = 'allOrNone';
   static const allRecords = 'allRecords';
   static const allRoles = 'allRoles';
-  static const allTeams = 'allTeams';
   static const allocation = 'allocation';
   static const allocationTarget = 'allocationTarget';
   static const allowAccess = 'allowAccess';
@@ -529,17 +499,17 @@ abstract class LocaleKeys {
   static const amountOfDaysMustBeLessThanLimit =
       'amountOfDaysMustBeLessThanLimit';
   static const amountOfDaysMustBePositive = 'amountOfDaysMustBePositive';
+  static const amountSteps = 'amountSteps';
+  static const amountStepsSettingValidator = 'amountStepsSettingValidator';
   static const anErrorOccurred = 'anErrorOccurred';
   static const analysisFirstRows = 'analysisFirstRows';
   static const analysisFirstRowsWithLockedRecords =
       'analysisFirstRowsWithLockedRecords';
   static const analyzingFirstRows = 'analyzingFirstRows';
-  static const and = 'and';
   static const andOperatorDescription = 'andOperatorDescription';
   static const android = 'android';
   static const anyCity = 'anyCity';
   static const anyStreet = 'anyStreet';
-  static const anyValue = 'anyValue';
   static const apiConnection = 'apiConnection';
   static const apiKey = 'apiKey';
   static const apiKeyAlreadySet = 'apiKeyAlreadySet';
@@ -551,9 +521,10 @@ abstract class LocaleKeys {
   static const apiKeyReference = 'apiKeyReference';
   static const apiKeyRole = 'apiKeyRole';
   static const apiKeyRoleExplanation = 'apiKeyRoleExplanation';
-  static const apiKeySettings = 'apiKeySettings';
   static const apiKeySuccessfullyCreated = 'apiKeySuccessfullyCreated';
   static const apiKeys = 'apiKeys';
+  static const apiKeysExplanation1 = 'apiKeysExplanation1';
+  static const apiKeysExplanation2 = 'apiKeysExplanation2';
   static const appearance = 'appearance';
   static const appearanceCells = 'appearanceCells';
   static const appearanceCellsExplanation = 'appearanceCellsExplanation';
@@ -576,7 +547,6 @@ abstract class LocaleKeys {
   static const approvalOrDenial = 'approvalOrDenial';
   static const approvalRequest = 'approvalRequest';
   static const approve = 'approve';
-  static const approveInvoice = 'approveInvoice';
   static const approved = 'approved';
   static const approvedAt = 'approvedAt';
   static const approvedRequest = 'approvedRequest';
@@ -584,12 +554,14 @@ abstract class LocaleKeys {
   static const approverName = 'approverName';
   static const approverRecord = 'approverRecord';
   static const arrangement = 'arrangement';
+  static const arrayNodeNames = 'arrayNodeNames';
+  static const arrayNodeNamesHelperText = 'arrayNodeNamesHelperText';
   static const arrow = 'arrow';
   static const ascending = 'ascending';
   static const ascii = 'ascii';
   static const askAiStep = 'askAiStep';
   static const askAiStepDescription = 'askAiStepDescription';
-  static const assignNumberAutomatically = 'assignNumberAutomatically';
+  static const askAiStepVariableExplanation = 'askAiStepVariableExplanation';
   static const assignee = 'assignee';
   static const at = 'at';
   static const attachments = 'attachments';
@@ -618,7 +590,6 @@ abstract class LocaleKeys {
   static const bankTransfer = 'bankTransfer';
   static const banner = 'banner';
   static const bannerAdjustments = 'bannerAdjustments';
-  static const bannerBetaGoToBetaButton = 'bannerBetaGoToBetaButton';
   static const bannerBetaGoToCurrentVersionButton =
       'bannerBetaGoToCurrentVersionButton';
   static const bannerBetaInfoBeta = 'bannerBetaInfoBeta';
@@ -628,12 +599,13 @@ abstract class LocaleKeys {
   static const bannerBetaInfoProdLink = 'bannerBetaInfoProdLink';
   static const bannerBetaReportProblemButton = 'bannerBetaReportProblemButton';
   static const bannerDraftGoToCostCenter = 'bannerDraftGoToCostCenter';
-  static const bannerHideButton = 'bannerHideButton';
   static const bannerHomescreen = 'bannerHomescreen';
+  static const barColor = 'barColor';
   static const barcode = 'barcode';
   static const base64DecodeDescription = 'base64DecodeDescription';
   static const base64EncodeDescription = 'base64EncodeDescription';
   static const base64ToBinaryDescription = 'base64ToBinaryDescription';
+  static const baseUrl = 'baseUrl';
   static const basedOnList = 'basedOnList';
   static const basedOnWorkflow = 'basedOnWorkflow';
   static const basic = 'basic';
@@ -649,23 +621,35 @@ abstract class LocaleKeys {
   static const betaTester = 'betaTester';
   static const bigQuery = 'bigQuery';
   static const bigQueryActivated = 'bigQueryActivated';
+  static const bigQueryCreateKey = 'bigQueryCreateKey';
+  static const bigQueryCreateKeyConfirm = 'bigQueryCreateKeyConfirm';
+  static const bigQueryCreateKeyConfirmDescription =
+      'bigQueryCreateKeyConfirmDescription';
+  static const bigQueryCreatingKey = 'bigQueryCreatingKey';
   static const bigQueryExplanation = 'bigQueryExplanation';
+  static const bigQueryKeyLimitReached = 'bigQueryKeyLimitReached';
+  static const bigQueryKeyOnlyShownOnce = 'bigQueryKeyOnlyShownOnce';
+  static const bigQueryKeyRevokeConfirm = 'bigQueryKeyRevokeConfirm';
+  static const bigQueryKeysSection = 'bigQueryKeysSection';
+  static const bigQueryNewKey = 'bigQueryNewKey';
+  static const bigQueryNoKeys = 'bigQueryNoKeys';
+  static const bigQueryOwnerOnly = 'bigQueryOwnerOnly';
+  static const bigQueryReloadKeys = 'bigQueryReloadKeys';
+  static const bigQueryRevokingKey = 'bigQueryRevokingKey';
+  static const bigQuerySavedAcknowledge = 'bigQuerySavedAcknowledge';
   static const billing = 'billing';
   static const billingAccount = 'billingAccount';
-  static const billingAccountAlreadyExists = 'billingAccountAlreadyExists';
-  static const billingAccountAlreadyExistsDescription =
-      'billingAccountAlreadyExistsDescription';
   static const billingAccountConnectionFailed =
       'billingAccountConnectionFailed';
   static const billingAccountLinkedPartner = 'billingAccountLinkedPartner';
   static const billingAccountNameChangeDescription =
       'billingAccountNameChangeDescription';
-  static const billingAccountNoPartner = 'billingAccountNoPartner';
-  static const billingAccountPartner = 'billingAccountPartner';
   static const billingAddress = 'billingAddress';
+  static const billingAdmin = 'billingAdmin';
   static const billingCycle = 'billingCycle';
   static const billingOptions = 'billingOptions';
   static const billingOptionsInfoText = 'billingOptionsInfoText';
+  static const billingOwner = 'billingOwner';
   static const billingType = 'billingType';
   static const binary = 'binary';
   static const binaryToBase64Description = 'binaryToBase64Description';
@@ -686,11 +670,12 @@ abstract class LocaleKeys {
   static const bottomRight = 'bottomRight';
   static const brick = 'brick';
   static const brickCanOnlyBeUsedOnce = 'brickCanOnlyBeUsedOnce';
-  static const brickEmpty = 'brickEmpty';
   static const brickId = 'brickId';
   static const brickNotImplemented = 'brickNotImplemented';
   static const brickReference = 'brickReference';
   static const brickSpecReference = 'brickSpecReference';
+  static const brickSpecTooltipInfo = 'brickSpecTooltipInfo';
+  static const brickSpecVariableDescription = 'brickSpecVariableDescription';
   static const brickSpecWithoutLabel = 'brickSpecWithoutLabel';
   static const bricks = 'bricks';
   static const bricksForSetting = 'bricksForSetting';
@@ -710,7 +695,6 @@ abstract class LocaleKeys {
   static const canEnter = 'canEnter';
   static const cancel = 'cancel';
   static const canceled = 'canceled';
-  static const cannotApproveRecord = 'cannotApproveRecord';
   static const cannotChangeBillingAccountName =
       'cannotChangeBillingAccountName';
   static const cannotChangeLicense = 'cannotChangeLicense';
@@ -749,7 +733,6 @@ abstract class LocaleKeys {
   static const changeFollowingFieldsToMakeRecordUnique =
       'changeFollowingFieldsToMakeRecordUnique';
   static const changeLicense = 'changeLicense';
-  static const changeOptionName = 'changeOptionName';
   static const changeOwner = 'changeOwner';
   static const changePassword = 'changePassword';
   static const changeStripeData = 'changeStripeData';
@@ -763,23 +746,14 @@ abstract class LocaleKeys {
       'changingBackgroundTypeWillDeleteImage';
   static const changingEmail = 'changingEmail';
   static const changingPassword = 'changingPassword';
-  static const changingWorkspace = 'changingWorkspace';
   static const chatGpt = 'chatGpt';
   static const chatGptBrickDescription = 'chatGptBrickDescription';
-  static const chatGptBrickDescriptionDescription =
-      'chatGptBrickDescriptionDescription';
   static const chatGptCurrentRecordPromptPart =
       'chatGptCurrentRecordPromptPart';
-  static const chatGptEnabled = 'chatGptEnabled';
   static const chatGptError = 'chatGptError';
   static const chatGptErrorTitle = 'chatGptErrorTitle';
   static const chatGptExamplePrompt = 'chatGptExamplePrompt';
   static const chatGptExecutionCanceled = 'chatGptExecutionCanceled';
-  static const chatGptExecutionCanceledContentFilter =
-      'chatGptExecutionCanceledContentFilter';
-  static const chatGptExecutionCanceledContentLength =
-      'chatGptExecutionCanceledContentLength';
-  static const chatGptExplanation = 'chatGptExplanation';
   static const chatGptImageBrickDescription = 'chatGptImageBrickDescription';
   static const chatGptImageInstructionPromptPart =
       'chatGptImageInstructionPromptPart';
@@ -795,10 +769,7 @@ abstract class LocaleKeys {
   static const chatGptSubListExplanationPromptPart =
       'chatGptSubListExplanationPromptPart';
   static const chatGptSystemPromptPart = 'chatGptSystemPromptPart';
-  static const chatGptTextFieldTooltip = 'chatGptTextFieldTooltip';
   static const chatGptThinking = 'chatGptThinking';
-  static const chatGptTileDescriptionDescription =
-      'chatGptTileDescriptionDescription';
   static const chatGptTimeEnvironmentPromptPart =
       'chatGptTimeEnvironmentPromptPart';
   static const chatGptUserEnvironmentPromptPart =
@@ -850,10 +821,10 @@ abstract class LocaleKeys {
   static const checkResultAllGood = 'checkResultAllGood';
   static const checkResultErrors = 'checkResultErrors';
   static const checkResultWarnings = 'checkResultWarnings';
-  static const checkWarningNoLinkedRecords = 'checkWarningNoLinkedRecords';
   static const checkWarningTooManyLinkedRecords =
       'checkWarningTooManyLinkedRecords';
   static const checkbox = 'checkbox';
+  static const checkboxNeedsToBeTicked = 'checkboxNeedsToBeTicked';
   static const checkedByDefault = 'checkedByDefault';
   static const checkedItems = 'checkedItems';
   static const checkingColumns = 'checkingColumns';
@@ -863,7 +834,6 @@ abstract class LocaleKeys {
   static const checklistDescription = 'checklistDescription';
   static const checkout = 'checkout';
   static const checkoutStepDescription = 'checkoutStepDescription';
-  static const checksPassedCorruptFiles = 'checksPassedCorruptFiles';
   static const checksPassedCyclicTransfers = 'checksPassedCyclicTransfers';
   static const checksPassedFormula = 'checksPassedFormula';
   static const checksPassedFormulaWorkflow = 'checksPassedFormulaWorkflow';
@@ -937,16 +907,14 @@ abstract class LocaleKeys {
   static const columnsMissingForSecondaryKeys =
       'columnsMissingForSecondaryKeys';
   static const combineDateAndTimeDescription = 'combineDateAndTimeDescription';
-  static const comingSoon = 'comingSoon';
   static const comma = 'comma';
   static const comment = 'comment';
   static const commentCannotBeEdited = 'commentCannotBeEdited';
-  static const commentCannotBeEmpty = 'commentCannotBeEmpty';
   static const commentIsTooOld = 'commentIsTooOld';
-  static const commentWithNumber = 'commentWithNumber';
   static const comments = 'comments';
   static const commentsBrickDescription = 'commentsBrickDescription';
   static const company = 'company';
+  static const companyDb = 'companyDb';
   static const companyLogo = 'companyLogo';
   static const companyName = 'companyName';
   static const companySizeBig = 'companySizeBig';
@@ -965,7 +933,6 @@ abstract class LocaleKeys {
   static const conditions = 'conditions';
   static const configuration = 'configuration';
   static const configurePermissions = 'configurePermissions';
-  static const configureRights = 'configureRights';
   static const confirm = 'confirm';
   static const confirmAbortFlow = 'confirmAbortFlow';
   static const confirmAndClose = 'confirmAndClose';
@@ -979,12 +946,20 @@ abstract class LocaleKeys {
   static const confirmDelete = 'confirmDelete';
   static const confirmDiscard = 'confirmDiscard';
   static const confirmEdit = 'confirmEdit';
+  static const confirmOptionRenameDescription =
+      'confirmOptionRenameDescription';
+  static const confirmOptionRenameInfo = 'confirmOptionRenameInfo';
+  static const confirmOptionRenameLabelWarning =
+      'confirmOptionRenameLabelWarning';
   static const confirmPassword = 'confirmPassword';
+  static const confirmReadingHint = 'confirmReadingHint';
   static const confirmRecordPickerFilterOnId = 'confirmRecordPickerFilterOnId';
   static const confirmResetDomainSettings = 'confirmResetDomainSettings';
   static const confirmRun = 'confirmRun';
   static const confirmShareList = 'confirmShareList';
+  static const confirmStatusRenameInfo = 'confirmStatusRenameInfo';
   static const confirmStopSharing = 'confirmStopSharing';
+  static const confirmTermRename = 'confirmTermRename';
   static const confirmUninstall = 'confirmUninstall';
   static const confirmUnlink = 'confirmUnlink';
   static const confirmUnlock = 'confirmUnlock';
@@ -1007,26 +982,40 @@ abstract class LocaleKeys {
   static const continueIfStepDescription = 'continueIfStepDescription';
   static const continue_ = 'continue_';
   static const conversations = 'conversations';
+  static const conversionMode = 'conversionMode';
+  static const conversionModeBadgerfish = 'conversionModeBadgerfish';
+  static const conversionModeBadgerfishDescription =
+      'conversionModeBadgerfishDescription';
+  static const conversionModeGData = 'conversionModeGData';
+  static const conversionModeGDataDescription =
+      'conversionModeGDataDescription';
+  static const conversionModeOpenRally = 'conversionModeOpenRally';
+  static const conversionModeOpenRallyDescription =
+      'conversionModeOpenRallyDescription';
+  static const conversionModeParker = 'conversionModeParker';
+  static const conversionModeParkerDescription =
+      'conversionModeParkerDescription';
+  static const conversionModeParkerWithAttrs = 'conversionModeParkerWithAttrs';
+  static const conversionModeParkerWithAttrsDescription =
+      'conversionModeParkerWithAttrsDescription';
   static const convertDocxToPdf = 'convertDocxToPdf';
   static const convertToPDFA = 'convertToPDFA';
   static const copiedToClipboard = 'copiedToClipboard';
   static const copy = 'copy';
-  static const copyInvitationLink = 'copyInvitationLink';
   static const copyLink = 'copyLink';
   static const copyValue = 'copyValue';
   static const copyright = 'copyright';
   static const costsPerBillingInterval = 'costsPerBillingInterval';
-  static const count = 'count';
   static const countDescription = 'countDescription';
   static const countRecordAmount = 'countRecordAmount';
   static const countRecordsFound = 'countRecordsFound';
   static const country = 'country';
   static const countryCode = 'countryCode';
-  static const countryOfTaxIDNotAccepted = 'countryOfTaxIDNotAccepted';
   static const create = 'create';
   static const createAccount = 'createAccount';
   static const createApiKey = 'createApiKey';
   static const createBillingAccount = 'createBillingAccount';
+  static const createCustomer = 'createCustomer';
   static const createDraftWSFailed = 'createDraftWSFailed';
   static const createForUser = 'createForUser';
   static const createIfNotFound = 'createIfNotFound';
@@ -1034,31 +1023,23 @@ abstract class LocaleKeys {
   static const createIntegrationsExplanation = 'createIntegrationsExplanation';
   static const createInvitationLink = 'createInvitationLink';
   static const createLabel = 'createLabel';
-  static const createMemberTile = 'createMemberTile';
   static const createNewApiKey = 'createNewApiKey';
-  static const createNewRecord = 'createNewRecord';
   static const createNewSolutionVersion = 'createNewSolutionVersion';
   static const createNewTrigger = 'createNewTrigger';
-  static const createNewWorkspace = 'createNewWorkspace';
-  static const createOption = 'createOption';
   static const createPdf = 'createPdf';
   static const createRecord = 'createRecord';
   static const createRecordIfNoneFound = 'createRecordIfNoneFound';
   static const createRecordStepDescription = 'createRecordStepDescription';
   static const createRuleWorkflow = 'createRuleWorkflow';
-  static const createRules = 'createRules';
   static const createSubscription = 'createSubscription';
   static const createSubscriptionInfo = 'createSubscriptionInfo';
   static const createUser = 'createUser';
   static const createUserExplanation = 'createUserExplanation';
-  static const createUserIfNotFound = 'createUserIfNotFound';
   static const createUserStepDescription = 'createUserStepDescription';
   static const createWorkflow = 'createWorkflow';
   static const createWorkspace = 'createWorkspace';
   static const createXml = 'createXml';
   static const createdAt = 'createdAt';
-  static const createdAtMonth = 'createdAtMonth';
-  static const createdAtWeek = 'createdAtWeek';
   static const createdBy = 'createdBy';
   static const creatingBackground = 'creatingBackground';
   static const creatingDemoWorkspace = 'creatingDemoWorkspace';
@@ -1076,14 +1057,17 @@ abstract class LocaleKeys {
   static const creditsApiV1Calls = 'creditsApiV1Calls';
   static const creditsApiV2Calls = 'creditsApiV2Calls';
   static const creditsBookedInfo = 'creditsBookedInfo';
+  static const creditsDiscount = 'creditsDiscount';
   static const creditsJob = 'creditsJob';
   static const creditsNextResetInfo = 'creditsNextResetInfo';
+  static const creditsNotAvailable = 'creditsNotAvailable';
   static const creditsSessions = 'creditsSessions';
   static const creditsTotal = 'creditsTotal';
   static const creditsUsed = 'creditsUsed';
   static const csvFieldDelimiter = 'csvFieldDelimiter';
   static const csvFile = 'csvFile';
   static const csvTextDelimiter = 'csvTextDelimiter';
+  static const currentBillingOwner = 'currentBillingOwner';
   static const currentList = 'currentList';
   static const currentLocation = 'currentLocation';
   static const currentMemberIdDescription = 'currentMemberIdDescription';
@@ -1096,6 +1080,7 @@ abstract class LocaleKeys {
   static const currentUserRoleIdDescription = 'currentUserRoleIdDescription';
   static const currentUserRoleNameDescription =
       'currentUserRoleNameDescription';
+  static const currentValue = 'currentValue';
   static const currentWeek = 'currentWeek';
   static const currentWeekDescription = 'currentWeekDescription';
   static const currentWorkspaceIdDescription = 'currentWorkspaceIdDescription';
@@ -1104,8 +1089,8 @@ abstract class LocaleKeys {
   static const customColors = 'customColors';
   static const customColumnWidth = 'customColumnWidth';
   static const customTitle = 'customTitle';
+  static const customerInformation = 'customerInformation';
   static const customerSupport = 'customerSupport';
-  static const customization = 'customization';
   static const cyclicDependency = 'cyclicDependency';
   static const daily = 'daily';
   static const dark = 'dark';
@@ -1129,6 +1114,7 @@ abstract class LocaleKeys {
   static const deactivateOption = 'deactivateOption';
   static const deactivateStatus = 'deactivateStatus';
   static const deactivated = 'deactivated';
+  static const decimalCountSettingValidator = 'decimalCountSettingValidator';
   static const decimalDegreeWithAbbreviation = 'decimalDegreeWithAbbreviation';
   static const decimalRoundDescription = 'decimalRoundDescription';
   static const defaultCamera = 'defaultCamera';
@@ -1156,6 +1142,9 @@ abstract class LocaleKeys {
   static const deleteAccount = 'deleteAccount';
   static const deleteAll = 'deleteAll';
   static const deleteAllReadNotifications = 'deleteAllReadNotifications';
+  static const deleteBillingAccount = 'deleteBillingAccount';
+  static const deleteBillingAccountNotImplemented =
+      'deleteBillingAccountNotImplemented';
   static const deleteEmptyRecords = 'deleteEmptyRecords';
   static const deleteFileStep = 'deleteFileStep';
   static const deleteFileStepDescription = 'deleteFileStepDescription';
@@ -1169,7 +1158,6 @@ abstract class LocaleKeys {
   static const deleteRecordStepDescription = 'deleteRecordStepDescription';
   static const deleteUnsubmittedRecord = 'deleteUnsubmittedRecord';
   static const deleteUser = 'deleteUser';
-  static const deleteWorkflow = 'deleteWorkflow';
   static const deleteWorkflowExecution = 'deleteWorkflowExecution';
   static const deleteWorkspace = 'deleteWorkspace';
   static const deleted = 'deleted';
@@ -1178,22 +1166,17 @@ abstract class LocaleKeys {
   static const deletingRecords = 'deletingRecords';
   static const deletingWorkspace = 'deletingWorkspace';
   static const delimiter = 'delimiter';
-  static const denial = 'denial';
   static const deniedAt = 'deniedAt';
   static const deniedRequest = 'deniedRequest';
   static const deny = 'deny';
   static const dependenciesNotPublished = 'dependenciesNotPublished';
   static const dependenciesNotPublishedDetail =
       'dependenciesNotPublishedDetail';
-  static const dependsOnFormat = 'dependsOnFormat';
   static const deprecated = 'deprecated';
   static const descending = 'descending';
   static const describeFormulaGoal = 'describeFormulaGoal';
   static const description = 'description';
-  static const descriptionFinishedJob = 'descriptionFinishedJob';
   static const descriptionOptional = 'descriptionOptional';
-  static const descriptionRunningJob = 'descriptionRunningJob';
-  static const descriptionWaitingJob = 'descriptionWaitingJob';
   static const deselectAll = 'deselectAll';
   static const design = 'design';
   static const designMode = 'designMode';
@@ -1204,11 +1187,13 @@ abstract class LocaleKeys {
   static const designModeNew = 'designModeNew';
   static const designModePreviewInfo = 'designModePreviewInfo';
   static const designSettingsTooltip = 'designSettingsTooltip';
+  static const desktop = 'desktop';
   static const detailView = 'detailView';
   static const detailViewDesign = 'detailViewDesign';
   static const detailViewMultiSelect = 'detailViewMultiSelect';
   static const detailViewMultiSelectExplanation =
       'detailViewMultiSelectExplanation';
+  static const details = 'details';
   static const device = 'device';
   static const differentTextOrNothing = 'differentTextOrNothing';
   static const differingFileName = 'differingFileName';
@@ -1224,18 +1209,18 @@ abstract class LocaleKeys {
   static const disableNotifications = 'disableNotifications';
   static const discard = 'discard';
   static const displayCouldTakeMoment = 'displayCouldTakeMoment';
+  static const displayTimeRange = 'displayTimeRange';
+  static const displayTimeRangeStart = 'displayTimeRangeStart';
+  static const displayTimeRangeStop = 'displayTimeRangeStop';
   static const distributionChannelLabel = 'distributionChannelLabel';
   static const divideDescription = 'divideDescription';
   static const divider = 'divider';
   static const doNotDuplicate = 'doNotDuplicate';
-  static const doNotTransferData = 'doNotTransferData';
   static const documentation = 'documentation';
   static const documentationCreated = 'documentationCreated';
   static const domain = 'domain';
-  static const domainExplanation = 'domainExplanation';
   static const domainSettingsInfo = 'domainSettingsInfo';
   static const done = 'done';
-  static const dot = 'dot';
   static const dotGrid = 'dotGrid';
   static const doubleArrow = 'doubleArrow';
   static const doubleQuote = 'doubleQuote';
@@ -1244,13 +1229,31 @@ abstract class LocaleKeys {
   static const downloadScript = 'downloadScript';
   static const downloadingFiles = 'downloadingFiles';
   static const downloadingLogs = 'downloadingLogs';
-  static const downloadingTemplate = 'downloadingTemplate';
   static const draft = 'draft';
   static const draftMessage = 'draftMessage';
   static const draftRemaining = 'draftRemaining';
-  static const draftTimeRemaining = 'draftTimeRemaining';
   static const draftWorkspace = 'draftWorkspace';
   static const draftWorkspaceExpired = 'draftWorkspaceExpired';
+  static const draftWorkspaceExpiryWarningBody =
+      'draftWorkspaceExpiryWarningBody';
+  static const draftWorkspaceExpiryWarningCtaText =
+      'draftWorkspaceExpiryWarningCtaText';
+  static const draftWorkspaceExpiryWarningHeader =
+      'draftWorkspaceExpiryWarningHeader';
+  static const draftWorkspaceExpiryWarningPreheader =
+      'draftWorkspaceExpiryWarningPreheader';
+  static const draftWorkspaceExpiryWarningSubject =
+      'draftWorkspaceExpiryWarningSubject';
+  static const draftWorkspaceInactivityWarningBody =
+      'draftWorkspaceInactivityWarningBody';
+  static const draftWorkspaceInactivityWarningCtaText =
+      'draftWorkspaceInactivityWarningCtaText';
+  static const draftWorkspaceInactivityWarningHeader =
+      'draftWorkspaceInactivityWarningHeader';
+  static const draftWorkspaceInactivityWarningPreheader =
+      'draftWorkspaceInactivityWarningPreheader';
+  static const draftWorkspaceInactivityWarningSubject =
+      'draftWorkspaceInactivityWarningSubject';
   static const dragFilesHere = 'dragFilesHere';
   static const drawing = 'drawing';
   static const drawingBrickDescription = 'drawingBrickDescription';
@@ -1261,7 +1264,6 @@ abstract class LocaleKeys {
   static const dueUntil = 'dueUntil';
   static const dummyMode = 'dummyMode';
   static const dummyModeDescription = 'dummyModeDescription';
-  static const dummySolution = 'dummySolution';
   static const duplicate = 'duplicate';
   static const duplicateDelete = 'duplicateDelete';
   static const duplicateRecord = 'duplicateRecord';
@@ -1271,24 +1273,19 @@ abstract class LocaleKeys {
   static const duplicateWorkflow = 'duplicateWorkflow';
   static const duplicatedRecordCheckFailedPlural =
       'duplicatedRecordCheckFailedPlural';
-  static const duplicatesFound = 'duplicatesFound';
   static const duplicatingTile = 'duplicatingTile';
   static const duration = 'duration';
   static const dynamicRecord = 'dynamicRecord';
   static const dynamicRecordPickerBrickDescription =
       'dynamicRecordPickerBrickDescription';
   static const dynamicValue = 'dynamicValue';
-  static const dynamicValueListOfDates = 'dynamicValueListOfDates';
-  static const dynamicValueOptional = 'dynamicValueOptional';
   static const earliestPossibleDate = 'earliestPossibleDate';
   static const edit = 'edit';
-  static const editAccountInformation = 'editAccountInformation';
   static const editAnyway = 'editAnyway';
   static const editBillingCycle = 'editBillingCycle';
   static const editBillingInformation = 'editBillingInformation';
   static const editBricks = 'editBricks';
   static const editCalendarShare = 'editCalendarShare';
-  static const editComment = 'editComment';
   static const editComponents = 'editComponents';
   static const editExistingTaxIdDenied = 'editExistingTaxIdDenied';
   static const editHeadline = 'editHeadline';
@@ -1307,33 +1304,33 @@ abstract class LocaleKeys {
   static const editWorkflow = 'editWorkflow';
   static const editingLicenses = 'editingLicenses';
   static const editor = 'editor';
+  static const editorConflict = 'editorConflict';
   static const editorDescription = 'editorDescription';
+  static const editorEditModePlaceholder = 'editorEditModePlaceholder';
   static const editorEmptyPlaceholder = 'editorEmptyPlaceholder';
   static const element = 'element';
-  static const elements = 'elements';
   static const email = 'email';
   static const emailAccount = 'emailAccount';
   static const emailAddressesSeparated = 'emailAddressesSeparated';
   static const emailBrickDescription = 'emailBrickDescription';
-  static const emailCannotBeChanged = 'emailCannotBeChanged';
-  static const emailCannotBeChangedExplanation =
-      'emailCannotBeChangedExplanation';
   static const emailDomains = 'emailDomains';
   static const emailDomainsAdd = 'emailDomainsAdd';
   static const emailDomainsExplanation = 'emailDomainsExplanation';
+  static const emailId = 'emailId';
   static const emailOptional = 'emailOptional';
+  static const emailReplyFrom = 'emailReplyFrom';
+  static const emailReplySent = 'emailReplySent';
+  static const emailReplySubject = 'emailReplySubject';
+  static const emailReplyTo = 'emailReplyTo';
   static const emailTemplate = 'emailTemplate';
   static const emailing = 'emailing';
-  static const emailingExplanation = 'emailingExplanation';
   static const emails = 'emails';
   static const embeddedInBrowser = 'embeddedInBrowser';
   static const embeddedList = 'embeddedList';
   static const embeddedMobile = 'embeddedMobile';
   static const embeddingNotPossible = 'embeddingNotPossible';
-  static const emptyAiChatHistory = 'emptyAiChatHistory';
   static const emptyDescription = 'emptyDescription';
   static const emptyTextField = 'emptyTextField';
-  static const emptyWorkspace = 'emptyWorkspace';
   static const emptyWorkspacesInfo = 'emptyWorkspacesInfo';
   static const enableDebugMode = 'enableDebugMode';
   static const enableMultiSelect = 'enableMultiSelect';
@@ -1353,14 +1350,13 @@ abstract class LocaleKeys {
   static const endOfWeekDescription = 'endOfWeekDescription';
   static const endOfYearDescription = 'endOfYearDescription';
   static const endTime = 'endTime';
-  static const enter = 'enter';
+  static const enlargeView = 'enlargeView';
   static const enterEmail = 'enterEmail';
   static const enterExpression = 'enterExpression';
   static const enterNumber = 'enterNumber';
   static const enterValidExpression = 'enterValidExpression';
   static const enterWorkspace = 'enterWorkspace';
   static const enteringWorkspace = 'enteringWorkspace';
-  static const entries = 'entries';
   static const entry = 'entry';
   static const entryPreview = 'entryPreview';
   static const entryPreviewTitle = 'entryPreviewTitle';
@@ -1377,16 +1373,18 @@ abstract class LocaleKeys {
   static const errorFlowAborted = 'errorFlowAborted';
   static const errorFlowStepSpec = 'errorFlowStepSpec';
   static const errorInExpression = 'errorInExpression';
-  static const errorLaunchingUrl = 'errorLaunchingUrl';
+  static const errorMessage = 'errorMessage';
   static const errorMissingSettings = 'errorMissingSettings';
-  static const errorOccurred = 'errorOccurred';
   static const errorOnFileDownload = 'errorOnFileDownload';
-  static const errorOption = 'errorOption';
   static const errorPleaseTryAgain = 'errorPleaseTryAgain';
   static const errorResolveShareUrl = 'errorResolveShareUrl';
+  static const errorScreenDetailsLabel = 'errorScreenDetailsLabel';
+  static const errorScreenSendMailToSupport = 'errorScreenSendMailToSupport';
+  static const errorScreenStackTrace = 'errorScreenStackTrace';
+  static const errorScreenSubheading = 'errorScreenSubheading';
   static const errorShareUrlMustBeFolder = 'errorShareUrlMustBeFolder';
   static const errorSolutionArchiveDeletion = 'errorSolutionArchiveDeletion';
-  static const errorUnsupportedSetting = 'errorUnsupportedSetting';
+  static const errorSupportMailSubject = 'errorSupportMailSubject';
   static const errorUploadFileToCloudStorage = 'errorUploadFileToCloudStorage';
   static const errorUploadFileToCloudStorageFileTooLarge =
       'errorUploadFileToCloudStorageFileTooLarge';
@@ -1399,6 +1397,8 @@ abstract class LocaleKeys {
   static const errorWhileProcessing = 'errorWhileProcessing';
   static const errorWhileStartingApp = 'errorWhileStartingApp';
   static const errorWhileTransferingData = 'errorWhileTransferingData';
+  static const errorWidgetReportProblemButton =
+      'errorWidgetReportProblemButton';
   static const errors = 'errors';
   static const errorsOccurred = 'errorsOccurred';
   static const eventDescription = 'eventDescription';
@@ -1414,8 +1414,8 @@ abstract class LocaleKeys {
   static const example = 'example';
   static const exampleFormulaPrompt = 'exampleFormulaPrompt';
   static const exampleJson = 'exampleJson';
+  static const examples = 'examples';
   static const excelSpreadsheet = 'excelSpreadsheet';
-  static const exceptionApiKeyNotFound = 'exceptionApiKeyNotFound';
   static const exceptionApprovalStatusMustBeInactive =
       'exceptionApprovalStatusMustBeInactive';
   static const exceptionBrickDoesNotHaveFileWithThisName =
@@ -1455,8 +1455,6 @@ abstract class LocaleKeys {
   static const exceptionCannotCreateSettingsRecord =
       'exceptionCannotCreateSettingsRecord';
   static const exceptionCannotCreateUser = 'exceptionCannotCreateUser';
-  static const exceptionCannotCreateUserWithMessage =
-      'exceptionCannotCreateUserWithMessage';
   static const exceptionCannotDeleteBrick = 'exceptionCannotDeleteBrick';
   static const exceptionCannotDeleteDefaultRole =
       'exceptionCannotDeleteDefaultRole';
@@ -1491,6 +1489,7 @@ abstract class LocaleKeys {
       'exceptionCannotImportListLinkedListNotFound';
   static const exceptionCannotImportSharedRecordSpecs =
       'exceptionCannotImportSharedRecordSpecs';
+  static const exceptionCannotInviteOwner = 'exceptionCannotInviteOwner';
   static const exceptionCannotLaunchLink = 'exceptionCannotLaunchLink';
   static const exceptionCannotLoadImage = 'exceptionCannotLoadImage';
   static const exceptionCannotLoadTemplate = 'exceptionCannotLoadTemplate';
@@ -1538,8 +1537,6 @@ abstract class LocaleKeys {
   static const exceptionErrorOccurred = 'exceptionErrorOccurred';
   static const exceptionErrorWhileSendingRequest =
       'exceptionErrorWhileSendingRequest';
-  static const exceptionErrorWhileSendingRequestWithMessage =
-      'exceptionErrorWhileSendingRequestWithMessage';
   static const exceptionExpectedArgument = 'exceptionExpectedArgument';
   static const exceptionExpectingList = 'exceptionExpectingList';
   static const exceptionExpression = 'exceptionExpression';
@@ -1568,16 +1565,11 @@ abstract class LocaleKeys {
   static const exceptionFlowStepSpecNotFound = 'exceptionFlowStepSpecNotFound';
   static const exceptionFlowUserInputInitialValueInvalidType =
       'exceptionFlowUserInputInitialValueInvalidType';
-  static const exceptionFolderUrlRequired = 'exceptionFolderUrlRequired';
   static const exceptionForbiddenFileExtension =
       'exceptionForbiddenFileExtension';
   static const exceptionFrontendFilters = 'exceptionFrontendFilters';
   static const exceptionGeneralError = 'exceptionGeneralError';
-  static const exceptionGetEmailsOnlySupportsAzure =
-      'exceptionGetEmailsOnlySupportsAzure';
   static const exceptionHttp = 'exceptionHttp';
-  static const exceptionHttp301 = 'exceptionHttp301';
-  static const exceptionHttp302 = 'exceptionHttp302';
   static const exceptionHttp400 = 'exceptionHttp400';
   static const exceptionHttp401 = 'exceptionHttp401';
   static const exceptionHttp403 = 'exceptionHttp403';
@@ -1604,8 +1596,6 @@ abstract class LocaleKeys {
   static const exceptionImportErrorForUser = 'exceptionImportErrorForUser';
   static const exceptionImportValue = 'exceptionImportValue';
   static const exceptionIndexOutOfRange = 'exceptionIndexOutOfRange';
-  static const exceptionInsufficientLicense = 'exceptionInsufficientLicense';
-  static const exceptionIntegrationNotFound = 'exceptionIntegrationNotFound';
   static const exceptionInvalidApiKey = 'exceptionInvalidApiKey';
   static const exceptionInvalidArgumentPower = 'exceptionInvalidArgumentPower';
   static const exceptionInvalidBricks = 'exceptionInvalidBricks';
@@ -1641,8 +1631,6 @@ abstract class LocaleKeys {
   static const exceptionInvalidFormatting = 'exceptionInvalidFormatting';
   static const exceptionInvalidIndexExpression =
       'exceptionInvalidIndexExpression';
-  static const exceptionInvalidLink = 'exceptionInvalidLink';
-  static const exceptionInvalidLinkedBricks = 'exceptionInvalidLinkedBricks';
   static const exceptionInvalidMailboxEmail = 'exceptionInvalidMailboxEmail';
   static const exceptionInvalidName = 'exceptionInvalidName';
   static const exceptionInvalidNameEnding = 'exceptionInvalidNameEnding';
@@ -1653,8 +1641,6 @@ abstract class LocaleKeys {
       'exceptionInvalidRecipientEmail';
   static const exceptionInvalidRepeat = 'exceptionInvalidRepeat';
   static const exceptionInvalidRepeatBrick = 'exceptionInvalidRepeatBrick';
-  static const exceptionInvalidRepeatShowIfArg =
-      'exceptionInvalidRepeatShowIfArg';
   static const exceptionInvalidRequestMethod = 'exceptionInvalidRequestMethod';
   static const exceptionInvalidRole = 'exceptionInvalidRole';
   static const exceptionInvalidSenderEmail = 'exceptionInvalidSenderEmail';
@@ -1670,7 +1656,6 @@ abstract class LocaleKeys {
   static const exceptionInvitationLinkFailed = 'exceptionInvitationLinkFailed';
   static const exceptionInvitationLinkNotValid =
       'exceptionInvitationLinkNotValid';
-  static const exceptionIterationFailed = 'exceptionIterationFailed';
   static const exceptionLicenseNotFound = 'exceptionLicenseNotFound';
   static const exceptionLicenseTooLow = 'exceptionLicenseTooLow';
   static const exceptionLinkedRecordSpecNotFound =
@@ -1703,14 +1688,12 @@ abstract class LocaleKeys {
   static const exceptionMissingAzureClientSecret =
       'exceptionMissingAzureClientSecret';
   static const exceptionMissingAzureTenantId = 'exceptionMissingAzureTenantId';
-  static const exceptionMissingBrickLabels = 'exceptionMissingBrickLabels';
   static const exceptionMissingBrickSpecId = 'exceptionMissingBrickSpecId';
+  static const exceptionMissingEmailId = 'exceptionMissingEmailId';
   static const exceptionMissingEmailOrPassword =
       'exceptionMissingEmailOrPassword';
-  static const exceptionMissingEmailProvider = 'exceptionMissingEmailProvider';
   static const exceptionMissingEmailVerificationSendGrid =
       'exceptionMissingEmailVerificationSendGrid';
-  static const exceptionMissingFile = 'exceptionMissingFile';
   static const exceptionMissingFileForImport = 'exceptionMissingFileForImport';
   static const exceptionMissingId = 'exceptionMissingId';
   static const exceptionMissingIntegration = 'exceptionMissingIntegration';
@@ -1735,11 +1718,6 @@ abstract class LocaleKeys {
   static const exceptionMissingPermissionsCreateList =
       'exceptionMissingPermissionsCreateList';
   static const exceptionMissingRecord = 'exceptionMissingRecord';
-  static const exceptionMissingSendGridApiKey =
-      'exceptionMissingSendGridApiKey';
-  static const exceptionMissingSesAccessKey = 'exceptionMissingSesAccessKey';
-  static const exceptionMissingSesRegion = 'exceptionMissingSesRegion';
-  static const exceptionMissingSesSecretKey = 'exceptionMissingSesSecretKey';
   static const exceptionMissingStorageFolderPath =
       'exceptionMissingStorageFolderPath';
   static const exceptionMissingTableFile = 'exceptionMissingTableFile';
@@ -1767,18 +1745,14 @@ abstract class LocaleKeys {
   static const exceptionNoRecordSelected = 'exceptionNoRecordSelected';
   static const exceptionNoWorkflowLinked = 'exceptionNoWorkflowLinked';
   static const exceptionNumberOfFilesReached = 'exceptionNumberOfFilesReached';
-  static const exceptionOpenAiIntegrationNoModelsFound =
-      'exceptionOpenAiIntegrationNoModelsFound';
   static const exceptionOptionDeactivated = 'exceptionOptionDeactivated';
   static const exceptionOptionListConstraints =
       'exceptionOptionListConstraints';
-  static const exceptionOptionNotFound = 'exceptionOptionNotFound';
   static const exceptionOptionNotFoundByNameOrId =
       'exceptionOptionNotFoundByNameOrId';
   static const exceptionOwnerAdminLicense = 'exceptionOwnerAdminLicense';
   static const exceptionParentFlowStepSpecNotFound =
       'exceptionParentFlowStepSpecNotFound';
-  static const exceptionPasswordRequired = 'exceptionPasswordRequired';
   static const exceptionPhoneNotValid = 'exceptionPhoneNotValid';
   static const exceptionRangeStep = 'exceptionRangeStep';
   static const exceptionReachedLicenseLimit = 'exceptionReachedLicenseLimit';
@@ -1789,16 +1763,12 @@ abstract class LocaleKeys {
   static const exceptionRecordNotFoundCannotImport =
       'exceptionRecordNotFoundCannotImport';
   static const exceptionRecordSpecNotFound = 'exceptionRecordSpecNotFound';
-  static const exceptionRecordSpecWithTemplateIdNotFound =
-      'exceptionRecordSpecWithTemplateIdNotFound';
   static const exceptionRecordTitleSemicolon = 'exceptionRecordTitleSemicolon';
-  static const exceptionRequest = 'exceptionRequest';
   static const exceptionRoleExternallySynced = 'exceptionRoleExternallySynced';
   static const exceptionRoleNotEnabled = 'exceptionRoleNotEnabled';
   static const exceptionRoleNotFound = 'exceptionRoleNotFound';
   static const exceptionRoleNotFoundById = 'exceptionRoleNotFoundById';
   static const exceptionRoleNotFoundByName = 'exceptionRoleNotFoundByName';
-  static const exceptionServerOnly = 'exceptionServerOnly';
   static const exceptionSettingValueNotPossible =
       'exceptionSettingValueNotPossible';
   static const exceptionSettingsTileAlreadyExists =
@@ -1815,6 +1785,8 @@ abstract class LocaleKeys {
       'exceptionSslOrStartTlsMustBeSelected';
   static const exceptionStartDateCannotBeAfterEndDate =
       'exceptionStartDateCannotBeAfterEndDate';
+  static const exceptionStaticIpProxyNotConfigured =
+      'exceptionStaticIpProxyNotConfigured';
   static const exceptionStatusDeactivated = 'exceptionStatusDeactivated';
   static const exceptionStatusNotFound = 'exceptionStatusNotFound';
   static const exceptionStatusNotFoundByNameOrId =
@@ -1846,7 +1818,6 @@ abstract class LocaleKeys {
   static const exceptionUiComponentNotFound = 'exceptionUiComponentNotFound';
   static const exceptionUnequalNumberOfOperators =
       'exceptionUnequalNumberOfOperators';
-  static const exceptionUnknownFormType = 'exceptionUnknownFormType';
   static const exceptionUnknownValueKey = 'exceptionUnknownValueKey';
   static const exceptionUserExpressions = 'exceptionUserExpressions';
   static const exceptionUserIsMissingEnabledRole =
@@ -1871,8 +1842,6 @@ abstract class LocaleKeys {
   static const exceptionWorkspaceNotLoaded = 'exceptionWorkspaceNotLoaded';
   static const exceptionWrongFileFormatCsv = 'exceptionWrongFileFormatCsv';
   static const exceptionWrongFileFormatXlsx = 'exceptionWrongFileFormatXlsx';
-  static const exceptionWrongPermissionsIntegration =
-      'exceptionWrongPermissionsIntegration';
   static const exhibition = 'exhibition';
   static const expDescription = 'expDescription';
   static const explainInvalidValueForBrick = 'explainInvalidValueForBrick';
@@ -1896,8 +1865,6 @@ abstract class LocaleKeys {
   static const externalUser = 'externalUser';
   static const externalUserRoleCouldNotBeActivatedEmailContent =
       'externalUserRoleCouldNotBeActivatedEmailContent';
-  static const externalUserRoleCouldNotBeSyncedEmailContent =
-      'externalUserRoleCouldNotBeSyncedEmailContent';
   static const externalUserRoleCouldNotBeSyncedWithRoleEmailContent =
       'externalUserRoleCouldNotBeSyncedWithRoleEmailContent';
   static const externalUserRoleSyncDescription =
@@ -1914,6 +1881,7 @@ abstract class LocaleKeys {
   static const extraInfoPrices4 = 'extraInfoPrices4';
   static const extraInfoPrices5 = 'extraInfoPrices5';
   static const failed = 'failed';
+  static const featureNotSupportedByModel = 'featureNotSupportedByModel';
   static const feedback = 'feedback';
   static const field = 'field';
   static const field1 = 'field1';
@@ -1925,10 +1893,8 @@ abstract class LocaleKeys {
   static const fields = 'fields';
   static const fieldsExplanation = 'fieldsExplanation';
   static const figure = 'figure';
-  static const figureOptional = 'figureOptional';
   static const file = 'file';
   static const fileBrickDescription = 'fileBrickDescription';
-  static const fileContent = 'fileContent';
   static const fileContentTextExample = 'fileContentTextExample';
   static const fileDestination = 'fileDestination';
   static const fileExtensions = 'fileExtensions';
@@ -1948,6 +1914,10 @@ abstract class LocaleKeys {
   static const fileNameWithoutType = 'fileNameWithoutType';
   static const fileNamesDescription = 'fileNamesDescription';
   static const filePickerBrickDescription = 'filePickerBrickDescription';
+  static const fileTapMode = 'fileTapMode';
+  static const fileTapModeDefaultApp = 'fileTapModeDefaultApp';
+  static const fileTapModePreview = 'fileTapModePreview';
+  static const fileTapModeShare = 'fileTapModeShare';
   static const fileTemplate = 'fileTemplate';
   static const fileType = 'fileType';
   static const fileUpload = 'fileUpload';
@@ -1959,14 +1929,12 @@ abstract class LocaleKeys {
   static const filterApprovers = 'filterApprovers';
   static const filterTitle = 'filterTitle';
   static const filterTitleMemberTile = 'filterTitleMemberTile';
-  static const filterWithNumber = 'filterWithNumber';
   static const filteredList = 'filteredList';
   static const filters = 'filters';
   static const filtersAndOrder = 'filtersAndOrder';
   static const filtersWithInvalidTypes = 'filtersWithInvalidTypes';
   static const findFirstRecord = 'findFirstRecord';
   static const findSolutions = 'findSolutions';
-  static const finished = 'finished';
   static const finishedAt = 'finishedAt';
   static const finishedEditing = 'finishedEditing';
   static const finishingImport = 'finishingImport';
@@ -2142,7 +2110,6 @@ abstract class LocaleKeys {
   static const flowAlreadyRunningBody = 'flowAlreadyRunningBody';
   static const flowAlreadyRunningTitle = 'flowAlreadyRunningTitle';
   static const flowButtonBrickDescription = 'flowButtonBrickDescription';
-  static const flowButtonNotPossible = 'flowButtonNotPossible';
   static const flowButtonsOnlyOnSideSlotPossible =
       'flowButtonsOnlyOnSideSlotPossible';
   static const flowDefaultEndMessage = 'flowDefaultEndMessage';
@@ -2151,10 +2118,12 @@ abstract class LocaleKeys {
   static const flowExceptionFileExpressionNoPdf =
       'flowExceptionFileExpressionNoPdf';
   static const flowExceptionFileListTooLong = 'flowExceptionFileListTooLong';
+  static const flowExceptionInvalidXml = 'flowExceptionInvalidXml';
   static const flowExceptionReturnValueTooBig =
       'flowExceptionReturnValueTooBig';
   static const flowExceptionWrongIntegrationTypeForAuthentication =
       'flowExceptionWrongIntegrationTypeForAuthentication';
+  static const flowExceptionXpathNoMatch = 'flowExceptionXpathNoMatch';
   static const flowLogAbortedByUser = 'flowLogAbortedByUser';
   static const flowLogAddedUser = 'flowLogAddedUser';
   static const flowLogAiAgentRespondedToPrompt =
@@ -2180,6 +2149,7 @@ abstract class LocaleKeys {
   static const flowLogErrorForRecord = 'flowLogErrorForRecord';
   static const flowLogErrorMarkingSomeEmailsRead =
       'flowLogErrorMarkingSomeEmailsRead';
+  static const flowLogErrorReplyingToEmail = 'flowLogErrorReplyingToEmail';
   static const flowLogErrorRetrievingEmails = 'flowLogErrorRetrievingEmails';
   static const flowLogErrorRetrievingEmailsWithMessage =
       'flowLogErrorRetrievingEmailsWithMessage';
@@ -2214,6 +2184,7 @@ abstract class LocaleKeys {
   static const flowLogRecordNotFound = 'flowLogRecordNotFound';
   static const flowLogRecordsFoundPlural = 'flowLogRecordsFoundPlural';
   static const flowLogRemovedUser = 'flowLogRemovedUser';
+  static const flowLogRepliedToEmail = 'flowLogRepliedToEmail';
   static const flowLogResetApproval = 'flowLogResetApproval';
   static const flowLogReturnedValue = 'flowLogReturnedValue';
   static const flowLogRunPath = 'flowLogRunPath';
@@ -2259,8 +2230,12 @@ abstract class LocaleKeys {
       'flowLogWarningStepNotAllowedForFlowType';
   static const flowLogWorkflowWillBeStartedAfterRules =
       'flowLogWorkflowWillBeStartedAfterRules';
+  static const flowLogXmlToJsonConverted = 'flowLogXmlToJsonConverted';
   static const flowMoreInfo = 'flowMoreInfo';
   static const flowMoreInfoDescription = 'flowMoreInfoDescription';
+  static const flowParamsExplanation = 'flowParamsExplanation';
+  static const flowStepSpecBrickVariableDescription =
+      'flowStepSpecBrickVariableDescription';
   static const flowTimedOut = 'flowTimedOut';
   static const flowTypeBusinessProcessAutomation =
       'flowTypeBusinessProcessAutomation';
@@ -2283,6 +2258,11 @@ abstract class LocaleKeys {
   static const forceDefaultOption = 'forceDefaultOption';
   static const forceDefaultStatus = 'forceDefaultStatus';
   static const forceScan = 'forceScan';
+  static const forest = 'forest';
+  static const forestColorSchemeAutumn = 'forestColorSchemeAutumn';
+  static const forestColorSchemeGreen = 'forestColorSchemeGreen';
+  static const forestColorSchemeLabel = 'forestColorSchemeLabel';
+  static const forestColorSchemeMonochrome = 'forestColorSchemeMonochrome';
   static const forgotPassword = 'forgotPassword';
   static const forgottenPassword = 'forgottenPassword';
   static const form = 'form';
@@ -2306,13 +2286,41 @@ abstract class LocaleKeys {
   static const fromRadixStringDescription = 'fromRadixStringDescription';
   static const frontCamera = 'frontCamera';
   static const fullTextSearch = 'fullTextSearch';
+  static const fullTextSearchLimitedQuotaExceededEmailBody =
+      'fullTextSearchLimitedQuotaExceededEmailBody';
+  static const fullTextSearchLimitedQuotaExceededEmailPreheader =
+      'fullTextSearchLimitedQuotaExceededEmailPreheader';
+  static const fullTextSearchLimitedQuotaExceededEmailSubject =
+      'fullTextSearchLimitedQuotaExceededEmailSubject';
+  static const fullTextSearchLimitedQuotaShowSettings =
+      'fullTextSearchLimitedQuotaShowSettings';
+  static const fullTextSearchMode = 'fullTextSearchMode';
+  static const fullTextSearchModeDisabled = 'fullTextSearchModeDisabled';
+  static const fullTextSearchModeDisabledDescription =
+      'fullTextSearchModeDisabledDescription';
+  static const fullTextSearchModeEnabled = 'fullTextSearchModeEnabled';
+  static const fullTextSearchModeEnabledDescription =
+      'fullTextSearchModeEnabledDescription';
+  static const fullTextSearchModeLimitedCount =
+      'fullTextSearchModeLimitedCount';
+  static const fullTextSearchModeLimitedCountDescription =
+      'fullTextSearchModeLimitedCountDescription';
+  static const fullTextSearchModeLimitedCountNotSelectableQuotaExceeded =
+      'fullTextSearchModeLimitedCountNotSelectableQuotaExceeded';
+  static const fullTextSearchModeRecent = 'fullTextSearchModeRecent';
+  static const fullTextSearchModeRecentDescription =
+      'fullTextSearchModeRecentDescription';
+  static const fullTextSearchMoreInfoDescription =
+      'fullTextSearchMoreInfoDescription';
+  static const fullTextSearchRecentModeWarning =
+      'fullTextSearchRecentModeWarning';
   static const fullUser = 'fullUser';
   static const fullscreenMode = 'fullscreenMode';
   static const functionOnlySupportsIosAndAndroid =
       'functionOnlySupportsIosAndAndroid';
   static const functions = 'functions';
+  static const gamification = 'gamification';
   static const general = 'general';
-  static const generate = 'generate';
   static const generateTechnicalName = 'generateTechnicalName';
   static const geoLocation = 'geoLocation';
   static const geoLocationBrickDescription = 'geoLocationBrickDescription';
@@ -2320,14 +2328,13 @@ abstract class LocaleKeys {
   static const geoLocationValueImportInvalidCoordinates =
       'geoLocationValueImportInvalidCoordinates';
   static const geoPositionEnteredManually = 'geoPositionEnteredManually';
-  static const german = 'german';
   static const germany = 'germany';
   static const getAllDescription = 'getAllDescription';
   static const getDescription = 'getDescription';
   static const getEmails = 'getEmails';
   static const getEmailsStepDescription = 'getEmailsStepDescription';
-  static const getEmailsStepOnlySupportsAzure =
-      'getEmailsStepOnlySupportsAzure';
+  static const getEmailsStepVariableExplanation =
+      'getEmailsStepVariableExplanation';
   static const getFirstDescription = 'getFirstDescription';
   static const getInTouch = 'getInTouch';
   static const getToKnowUnivelop = 'getToKnowUnivelop';
@@ -2340,7 +2347,7 @@ abstract class LocaleKeys {
   static const greaterThanDescription = 'greaterThanDescription';
   static const greaterThanOrEqualDescription = 'greaterThanOrEqualDescription';
   static const greeting = 'greeting';
-  static const greetingWithoutName = 'greetingWithoutName';
+  static const greetingsByUnivelop = 'greetingsByUnivelop';
   static const grid = 'grid';
   static const hasValidCredentials = 'hasValidCredentials';
   static const header = 'header';
@@ -2361,6 +2368,7 @@ abstract class LocaleKeys {
   static const hideTile = 'hideTile';
   static const hideTileForMe = 'hideTileForMe';
   static const hideTour = 'hideTour';
+  static const hideTransfers = 'hideTransfers';
   static const high = 'high';
   static const highestPossibleNumber = 'highestPossibleNumber';
   static const hint = 'hint';
@@ -2373,7 +2381,6 @@ abstract class LocaleKeys {
   static const homeEditScreenTitle = 'homeEditScreenTitle';
   static const homeScreen = 'homeScreen';
   static const horizontal = 'horizontal';
-  static const hoursAbbrev = 'hoursAbbrev';
   static const hoursBetweenDescription = 'hoursBetweenDescription';
   static const hoursDescription = 'hoursDescription';
   static const houseNumber = 'houseNumber';
@@ -2384,7 +2391,6 @@ abstract class LocaleKeys {
   static const icon = 'icon';
   static const id = 'id';
   static const idBrickTooltip = 'idBrickTooltip';
-  static const ids = 'ids';
   static const ifDescription = 'ifDescription';
   static const ifElseDescription = 'ifElseDescription';
   static const ignore = 'ignore';
@@ -2399,7 +2405,6 @@ abstract class LocaleKeys {
       'imagePickerDuplicateExplanation';
   static const imagePlaceholderSemanticLabel = 'imagePlaceholderSemanticLabel';
   static const imagePlural = 'imagePlural';
-  static const imageRecognition = 'imageRecognition';
   static const imageSignIn = 'imageSignIn';
   static const imageUpload = 'imageUpload';
   static const imapServerHost = 'imapServerHost';
@@ -2413,6 +2418,8 @@ abstract class LocaleKeys {
   static const importFromExcel = 'importFromExcel';
   static const importTable = 'importTable';
   static const importTableStepDescription = 'importTableStepDescription';
+  static const importTableStepVariableExplanation =
+      'importTableStepVariableExplanation';
   static const importTile = 'importTile';
   static const importWorkflow = 'importWorkflow';
   static const importWorkspace = 'importWorkspace';
@@ -2459,16 +2466,15 @@ abstract class LocaleKeys {
   static const industryTransportationAndLogistics =
       'industryTransportationAndLogistics';
   static const info = 'info';
+  static const infoChangeBillingAddress = 'infoChangeBillingAddress';
   static const infoForPersonalization = 'infoForPersonalization';
+  static const infoTextChangeBillingCycle = 'infoTextChangeBillingCycle';
+  static const infoTransferBillingOwner = 'infoTransferBillingOwner';
   static const initialValue = 'initialValue';
-  static const inputText = 'inputText';
   static const inputValues = 'inputValues';
   static const insert = 'insert';
   static const insertToday = 'insertToday';
   static const install = 'install';
-  static const installRecordsOnlyIfExported = 'installRecordsOnlyIfExported';
-  static const installRolesOnlyIfExported = 'installRolesOnlyIfExported';
-  static const installSettingsOnlyIfExported = 'installSettingsOnlyIfExported';
   static const installSolutionInWorkspace = 'installSolutionInWorkspace';
   static const installWithDemoData = 'installWithDemoData';
   static const installWithRoles = 'installWithRoles';
@@ -2479,6 +2485,7 @@ abstract class LocaleKeys {
   static const installedSolutions = 'installedSolutions';
   static const installingSolution = 'installingSolution';
   static const integration = 'integration';
+  static const integrationNotValidated = 'integrationNotValidated';
   static const integrationPrivacyPolicy = 'integrationPrivacyPolicy';
   static const integrationType = 'integrationType';
   static const integrations = 'integrations';
@@ -2490,36 +2497,43 @@ abstract class LocaleKeys {
   static const invalidCoordinates = 'invalidCoordinates';
   static const invalidCoordinatesExplanation = 'invalidCoordinatesExplanation';
   static const invalidCountryCode = 'invalidCountryCode';
-  static const invalidEmail = 'invalidEmail';
   static const invalidExpression = 'invalidExpression';
   static const invalidFileName = 'invalidFileName';
   static const invalidInstalledSolutionTip = 'invalidInstalledSolutionTip';
   static const invalidIntegration = 'invalidIntegration';
+  static const invalidIntegrationNotOpenAi = 'invalidIntegrationNotOpenAi';
   static const invalidInvitationLinks = 'invalidInvitationLinks';
   static const invalidJson = 'invalidJson';
   static const invalidLink = 'invalidLink';
-  static const invalidPhoneNumber = 'invalidPhoneNumber';
-  static const invalidPostalCode = 'invalidPostalCode';
-  static const invalidPostalCodeDescription = 'invalidPostalCodeDescription';
   static const invalidSetting = 'invalidSetting';
-  static const invalidTaxId = 'invalidTaxId';
-  static const invalidUrl = 'invalidUrl';
   static const invalidXmlTemplate = 'invalidXmlTemplate';
   static const invitation = 'invitation';
+  static const invitationCurrentValidity = 'invitationCurrentValidity';
+  static const invitationExpiresAt = 'invitationExpiresAt';
   static const invitationInvalid = 'invitationInvalid';
   static const invitationLink = 'invitationLink';
+  static const invitationLinkValue = 'invitationLinkValue';
   static const invitationLinks = 'invitationLinks';
+  static const invitationNeverExpires = 'invitationNeverExpires';
   static const invitationStepDescription = 'invitationStepDescription';
+  static const invitationValidFor = 'invitationValidFor';
+  static const invitationValidFor1Year = 'invitationValidFor1Year';
+  static const invitationValidFor30Days = 'invitationValidFor30Days';
+  static const invitationValidFor7Days = 'invitationValidFor7Days';
+  static const invitationValidUntilWithRemaining =
+      'invitationValidUntilWithRemaining';
   static const invitationWrongUser = 'invitationWrongUser';
   static const inviteUser = 'inviteUser';
   static const inviteUserExplanation = 'inviteUserExplanation';
   static const invited = 'invited';
   static const invitedToWorkspace = 'invitedToWorkspace';
   static const invoice = 'invoice';
-  static const invoiceApproved = 'invoiceApproved';
   static const invoiceBilling = 'invoiceBilling';
   static const invoiceInfo1 = 'invoiceInfo1';
   static const invoiceInfo2 = 'invoiceInfo2';
+  static const invoiceScreenTitle = 'invoiceScreenTitle';
+  static const invoiceTaxConfirmationMessage = 'invoiceTaxConfirmationMessage';
+  static const invoiceTaxConfirmationTitle = 'invoiceTaxConfirmationTitle';
   static const isDependencyOfPublished = 'isDependencyOfPublished';
   static const isDependencyOfPublishedDetail = 'isDependencyOfPublishedDetail';
   static const isDuplicate = 'isDuplicate';
@@ -2547,6 +2561,8 @@ abstract class LocaleKeys {
   static const joiningSettingsExplanation = 'joiningSettingsExplanation';
   static const json = 'json';
   static const jsonEncodeDescription = 'jsonEncodeDescription';
+  static const jsonObjectWithValues = 'jsonObjectWithValues';
+  static const jsonOutput = 'jsonOutput';
   static const kanbanBoard = 'kanbanBoard';
   static const kanbanDescription = 'kanbanDescription';
   static const kanbanSetSettings = 'kanbanSetSettings';
@@ -2581,12 +2597,10 @@ abstract class LocaleKeys {
   static const learnMore = 'learnMore';
   static const leave = 'leave';
   static const leaveDesignMode = 'leaveDesignMode';
-  static const leaveEditMode = 'leaveEditMode';
   static const leavePeriod = 'leavePeriod';
   static const leaveWorkspace = 'leaveWorkspace';
   static const leaveWorkspaceWithName = 'leaveWorkspaceWithName';
   static const leavingWorkspace = 'leavingWorkspace';
-  static const leftBox = 'leftBox';
   static const legalMatters = 'legalMatters';
   static const legalNotice = 'legalNotice';
   static const lessThanDescription = 'lessThanDescription';
@@ -2595,13 +2609,13 @@ abstract class LocaleKeys {
   static const licenseAdmin = 'licenseAdmin';
   static const licenseBooking = 'licenseBooking';
   static const licenseExternal = 'licenseExternal';
-  static const licenseInfo = 'licenseInfo';
   static const licenseLightL = 'licenseLightL';
   static const licenseLightM = 'licenseLightM';
   static const licenseLightPartTime = 'licenseLightPartTime';
   static const licenseLightS = 'licenseLightS';
   static const licenseLightXS = 'licenseLightXS';
   static const licenseName = 'licenseName';
+  static const licensePartner = 'licensePartner';
   static const licensePro = 'licensePro';
   static const licenseReductionNotAllowed = 'licenseReductionNotAllowed';
   static const licenseTest = 'licenseTest';
@@ -2623,6 +2637,7 @@ abstract class LocaleKeys {
   static const limitRoleAccess = 'limitRoleAccess';
   static const limited = 'limited';
   static const line = 'line';
+  static const linear = 'linear';
   static const link = 'link';
   static const linkColumn = 'linkColumn';
   static const linkNotSupported = 'linkNotSupported';
@@ -2635,7 +2650,6 @@ abstract class LocaleKeys {
   static const linkToBrick = 'linkToBrick';
   static const linkToDate = 'linkToDate';
   static const linkToFile = 'linkToFile';
-  static const linkToImage = 'linkToImage';
   static const linkToList = 'linkToList';
   static const linkToListNoun = 'linkToListNoun';
   static const linkToResource = 'linkToResource';
@@ -2646,11 +2660,8 @@ abstract class LocaleKeys {
   static const linkedRecordForFileExplanation =
       'linkedRecordForFileExplanation';
   static const linkedRecordId = 'linkedRecordId';
-  static const linkingOfRecords = 'linkingOfRecords';
   static const list = 'list';
   static const listDifferenceDescription = 'listDifferenceDescription';
-  static const listDynamicValue = 'listDynamicValue';
-  static const listEqualsDEscription = 'listEqualsDEscription';
   static const listEqualsDescription = 'listEqualsDescription';
   static const listExpression = 'listExpression';
   static const listExpressionBrickDescription =
@@ -2667,21 +2678,21 @@ abstract class LocaleKeys {
   static const listToTextDescription = 'listToTextDescription';
   static const listUnionDescription = 'listUnionDescription';
   static const listView = 'listView';
-  static const listViewConfiguration = 'listViewConfiguration';
-  static const listViewDesign = 'listViewDesign';
-  static const listViewReference = 'listViewReference';
   static const listWithLabel = 'listWithLabel';
   static const lists = 'lists';
   static const lnDescription = 'lnDescription';
   static const loadAndShow = 'loadAndShow';
   static const loadMore = 'loadMore';
+  static const loadOrCreateRecord = 'loadOrCreateRecord';
   static const loadOrCreateRecords = 'loadOrCreateRecords';
   static const loading = 'loading';
+  static const loadingBillingAccount = 'loadingBillingAccount';
+  static const loadingBillingInfo = 'loadingBillingInfo';
   static const loadingFile = 'loadingFile';
   static const loadingForm = 'loadingForm';
   static const loadingLocation = 'loadingLocation';
   static const loadingMemberRecord = 'loadingMemberRecord';
-  static const loadingPage = 'loadingPage';
+  static const loadingPublicInfo = 'loadingPublicInfo';
   static const loadingWithName = 'loadingWithName';
   static const localFile = 'localFile';
   static const localImage = 'localImage';
@@ -2708,6 +2719,7 @@ abstract class LocaleKeys {
   static const lookOnly = 'lookOnly';
   static const low = 'low';
   static const mailbox = 'mailbox';
+  static const manageBillingAdmins = 'manageBillingAdmins';
   static const manageInvitations = 'manageInvitations';
   static const manageLabels = 'manageLabels';
   static const manageLicenses = 'manageLicenses';
@@ -2729,7 +2741,6 @@ abstract class LocaleKeys {
   static const markAsRead = 'markAsRead';
   static const markAsUnread = 'markAsUnread';
   static const markEmailsReadAfterRetrieval = 'markEmailsReadAfterRetrieval';
-  static const markdownDocsTable = 'markdownDocsTable';
   static const marketingManagement = 'marketingManagement';
   static const matrix = 'matrix';
   static const matrixBrickDeleteRecordsExplanation =
@@ -2738,7 +2749,6 @@ abstract class LocaleKeys {
   static const matrixColumnWidthTooSmall = 'matrixColumnWidthTooSmall';
   static const matrixHideTotalOnSmallScreens = 'matrixHideTotalOnSmallScreens';
   static const matrixSetSettings = 'matrixSetSettings';
-  static const max30Chars = 'max30Chars';
   static const maxChars = 'maxChars';
   static const maxDateRangeDays = 'maxDateRangeDays';
   static const maxDescription = 'maxDescription';
@@ -2746,6 +2756,7 @@ abstract class LocaleKeys {
   static const maxNumberFiles = 'maxNumberFiles';
   static const maxNumberImages = 'maxNumberImages';
   static const maxOptionAmountReached = 'maxOptionAmountReached';
+  static const maximum = 'maximum';
   static const maximumBrickCountReached = 'maximumBrickCountReached';
   static const maximumPreviewExceeded = 'maximumPreviewExceeded';
   static const maximumTriggersOnRecordSpecReached =
@@ -2754,11 +2765,9 @@ abstract class LocaleKeys {
   static const measureBrickDescription = 'measureBrickDescription';
   static const mediocreHappyUserPlaceholder = 'mediocreHappyUserPlaceholder';
   static const medium = 'medium';
-  static const memberList = 'memberList';
   static const memberMissing = 'memberMissing';
   static const memberMissingExplanation = 'memberMissingExplanation';
   static const memberTileHolidayCoverTooltip = 'memberTileHolidayCoverTooltip';
-  static const memberTileSetupInvalid = 'memberTileSetupInvalid';
   static const members = 'members';
   static const mentionedYou = 'mentionedYou';
   static const mergePdfLinkExplanation = 'mergePdfLinkExplanation';
@@ -2773,19 +2782,16 @@ abstract class LocaleKeys {
   static const microsoftGraphSubscriptions = 'microsoftGraphSubscriptions';
   static const microsoftGraphSubscriptionsApiKeyDescription =
       'microsoftGraphSubscriptionsApiKeyDescription';
-  static const minAbbrev = 'minAbbrev';
   static const minDescription = 'minDescription';
   static const mine = 'mine';
+  static const minimum = 'minimum';
   static const minimumLicense = 'minimumLicense';
   static const minusDescription = 'minusDescription';
   static const minutes = 'minutes';
   static const minutesDescription = 'minutesDescription';
   static const missingBackgroundImage = 'missingBackgroundImage';
-  static const missingChatGptKey = 'missingChatGptKey';
   static const missingConnection = 'missingConnection';
-  static const missingDirectory = 'missingDirectory';
   static const missingFile = 'missingFile';
-  static const missingLinkedRecord = 'missingLinkedRecord';
   static const missingMemberTile = 'missingMemberTile';
   static const missingName = 'missingName';
   static const missingPartnerId = 'missingPartnerId';
@@ -2799,12 +2805,11 @@ abstract class LocaleKeys {
   static const missingSignature = 'missingSignature';
   static const missingTechName = 'missingTechName';
   static const missingUserPicker = 'missingUserPicker';
+  static const mobile = 'mobile';
   static const mobileScannerOnlyMobile = 'mobileScannerOnlyMobile';
   static const mode = 'mode';
   static const model = 'model';
   static const modifiedAt = 'modifiedAt';
-  static const modifiedAtMonth = 'modifiedAtMonth';
-  static const modifiedAtWeek = 'modifiedAtWeek';
   static const modifiedBy = 'modifiedBy';
   static const modifiedInMonth = 'modifiedInMonth';
   static const modifyRecord = 'modifyRecord';
@@ -2812,12 +2817,10 @@ abstract class LocaleKeys {
   static const moduloDescription = 'moduloDescription';
   static const mondayAbbreviated = 'mondayAbbreviated';
   static const month = 'month';
-  static const monthText = 'monthText';
   static const monthly = 'monthly';
   static const monthlyNominative = 'monthlyNominative';
   static const more = 'more';
   static const moreInfo = 'moreInfo';
-  static const moreSettings = 'moreSettings';
   static const moreWithNumber = 'moreWithNumber';
   static const move = 'move';
   static const moveBrickToTab = 'moveBrickToTab';
@@ -2846,16 +2849,12 @@ abstract class LocaleKeys {
   static const navigateToRecord = 'navigateToRecord';
   static const navigation = 'navigation';
   static const navigationBrickDescription = 'navigationBrickDescription';
-  static const navigationBrickTooManyRecords = 'navigationBrickTooManyRecords';
-  static const needConnectionForChatGpt = 'needConnectionForChatGpt';
   static const needConnectionForSavingFiles = 'needConnectionForSavingFiles';
   static const never = 'never';
   static const newApiKey = 'newApiKey';
   static const newAssignment = 'newAssignment';
   static const newCalendarShare = 'newCalendarShare';
   static const newChat = 'newChat';
-  static const newConversation = 'newConversation';
-  static const newCustomizationSolution = 'newCustomizationSolution';
   static const newEmailAddress = 'newEmailAddress';
   static const newFile = 'newFile';
   static const newFolder = 'newFolder';
@@ -2867,7 +2866,6 @@ abstract class LocaleKeys {
   static const newRow = 'newRow';
   static const newSolution = 'newSolution';
   static const newSolutionWorkspace = 'newSolutionWorkspace';
-  static const newStatus = 'newStatus';
   static const newTiles = 'newTiles';
   static const newUser = 'newUser';
   static const newValue = 'newValue';
@@ -2883,7 +2881,6 @@ abstract class LocaleKeys {
   static const nextWeek = 'nextWeek';
   static const no = 'no';
   static const noAccess = 'noAccess';
-  static const noAccessToWS = 'noAccessToWS';
   static const noAccount = 'noAccount';
   static const noActionButtons = 'noActionButtons';
   static const noActionButtonsInBrickSectionAllowed =
@@ -2899,11 +2896,14 @@ abstract class LocaleKeys {
   static const noAssignments = 'noAssignments';
   static const noBackground = 'noBackground';
   static const noBadge = 'noBadge';
+  static const noBillingAccount = 'noBillingAccount';
+  static const noBillingAccounts = 'noBillingAccounts';
+  static const noBillingAccountsConnected = 'noBillingAccountsConnected';
+  static const noBillingAdmins = 'noBillingAdmins';
   static const noBrickInListView = 'noBrickInListView';
   static const noBrickInRecordSpec = 'noBrickInRecordSpec';
   static const noBricksInActionButtonSectionAllowed =
       'noBricksInActionButtonSectionAllowed';
-  static const noBricksInGroup = 'noBricksInGroup';
   static const noBricksSelected = 'noBricksSelected';
   static const noCalendarShares = 'noCalendarShares';
   static const noChangesYet = 'noChangesYet';
@@ -2912,7 +2912,6 @@ abstract class LocaleKeys {
   static const noCodeExperienceLabel = 'noCodeExperienceLabel';
   static const noCodeExperienceNovice = 'noCodeExperienceNovice';
   static const noCodeNoLimit = 'noCodeNoLimit';
-  static const noColumns = 'noColumns';
   static const noComments = 'noComments';
   static const noConnectedBillingAccountsForPartner =
       'noConnectedBillingAccountsForPartner';
@@ -2923,16 +2922,14 @@ abstract class LocaleKeys {
   static const noDocumentsImported = 'noDocumentsImported';
   static const noDomains = 'noDomains';
   static const noEntriesFound = 'noEntriesFound';
-  static const noErrorMessage = 'noErrorMessage';
   static const noFiles = 'noFiles';
   static const noFiltering = 'noFiltering';
   static const noFilters = 'noFilters';
-  static const noFinishedJobs = 'noFinishedJobs';
   static const noFormulaSelected = 'noFormulaSelected';
   static const noIntegrationFound = 'noIntegrationFound';
   static const noIntegrationSelected = 'noIntegrationSelected';
+  static const noIntegrationsFound = 'noIntegrationsFound';
   static const noInvoice = 'noInvoice';
-  static const noInvoices = 'noInvoices';
   static const noJobsFound = 'noJobsFound';
   static const noLabel = 'noLabel';
   static const noLabelWithClassName = 'noLabelWithClassName';
@@ -2948,7 +2945,7 @@ abstract class LocaleKeys {
   static const noNextInvoiceDueToCancellation =
       'noNextInvoiceDueToCancellation';
   static const noNotifications = 'noNotifications';
-  static const noOptionChosen = 'noOptionChosen';
+  static const noOpenAiIntegrationConfigured = 'noOpenAiIntegrationConfigured';
   static const noOptions = 'noOptions';
   static const noOptionsFound = 'noOptionsFound';
   static const noParameters = 'noParameters';
@@ -2963,8 +2960,7 @@ abstract class LocaleKeys {
   static const noResultsFor = 'noResultsFor';
   static const noResultsInTheLastSixMonths = 'noResultsInTheLastSixMonths';
   static const noReturnValues = 'noReturnValues';
-  static const noRows = 'noRows';
-  static const noRunningJobs = 'noRunningJobs';
+  static const noScheduledJobWarning = 'noScheduledJobWarning';
   static const noSelection = 'noSelection';
   static const noSendOffPossible = 'noSendOffPossible';
   static const noSolutionFound = 'noSolutionFound';
@@ -2981,12 +2977,9 @@ abstract class LocaleKeys {
   static const noUserActivityInWorkspace = 'noUserActivityInWorkspace';
   static const noVariables = 'noVariables';
   static const noVersion = 'noVersion';
-  static const noWaitingJobs = 'noWaitingJobs';
   static const noWorkflows = 'noWorkflows';
   static const noWorkspacesFound = 'noWorkspacesFound';
-  static const nonTextValue = 'nonTextValue';
   static const none = 'none';
-  static const not = 'not';
   static const notAllowedOperation = 'notAllowedOperation';
   static const notAvailableForGetRequests = 'notAvailableForGetRequests';
   static const notAvailableInBeta = 'notAvailableInBeta';
@@ -3015,6 +3008,7 @@ abstract class LocaleKeys {
   static const notificationsForInsertedUser = 'notificationsForInsertedUser';
   static const nowDescription = 'nowDescription';
   static const npsQuestion = 'npsQuestion';
+  static const nthValue = 'nthValue';
   static const number = 'number';
   static const numberAsDots = 'numberAsDots';
   static const numberColumnsPreview = 'numberColumnsPreview';
@@ -3038,9 +3032,6 @@ abstract class LocaleKeys {
   static const numberRowsPreview = 'numberRowsPreview';
   static const numberSelected = 'numberSelected';
   static const numberText = 'numberText';
-  static const numbers = 'numbers';
-  static const object = 'object';
-  static const objectHasToMatch = 'objectHasToMatch';
   static const objectiveDataAccessLabel = 'objectiveDataAccessLabel';
   static const objectiveDigitalizationLabel = 'objectiveDigitalizationLabel';
   static const objectiveProcessesLabel = 'objectiveProcessesLabel';
@@ -3061,7 +3052,6 @@ abstract class LocaleKeys {
   static const onboardingCreateContacts = 'onboardingCreateContacts';
   static const onboardingCreateContactsDescription =
       'onboardingCreateContactsDescription';
-  static const onboardingDismiss = 'onboardingDismiss';
   static const onboardingExploreDesignMode = 'onboardingExploreDesignMode';
   static const onboardingExploreDesignModeDescription =
       'onboardingExploreDesignModeDescription';
@@ -3070,13 +3060,12 @@ abstract class LocaleKeys {
   static const onboardingInstallSolution = 'onboardingInstallSolution';
   static const onboardingInstallSolutionDescription =
       'onboardingInstallSolutionDescription';
-  static const onboardingResetVisibility = 'onboardingResetVisibility';
   static const onboardingResetVisibilitySuccess =
       'onboardingResetVisibilitySuccess';
   static const onboardingWasReset = 'onboardingWasReset';
-  static const onboardingWorkspaceAlreadyExists =
-      'onboardingWorkspaceAlreadyExists';
   static const oneWeek = 'oneWeek';
+  static const onlyChangeableByBillingAccountOwnerOrAdmin =
+      'onlyChangeableByBillingAccountOwnerOrAdmin';
   static const onlyChangeableByOwner = 'onlyChangeableByOwner';
   static const onlyOneInteractiveElementPerSlot =
       'onlyOneInteractiveElementPerSlot';
@@ -3092,8 +3081,8 @@ abstract class LocaleKeys {
   static const openEditMode = 'openEditMode';
   static const openFolder = 'openFolder';
   static const openInExternalBrowser = 'openInExternalBrowser';
-  static const openLink = 'openLink';
   static const openLinkedResource = 'openLinkedResource';
+  static const openPlanner = 'openPlanner';
   static const openRecord = 'openRecord';
   static const openScanner = 'openScanner';
   static const openScreenStep = 'openScreenStep';
@@ -3105,20 +3094,15 @@ abstract class LocaleKeys {
   static const optionLabel = 'optionLabel';
   static const optionLabelAlreadyInUse = 'optionLabelAlreadyInUse';
   static const optionLabelCannotBeEmpty = 'optionLabelCannotBeEmpty';
-  static const optionName = 'optionName';
   static const optionSettings = 'optionSettings';
   static const optionWithNumber = 'optionWithNumber';
   static const optionalSuffix = 'optionalSuffix';
-  static const optionalTextWeekdays = 'optionalTextWeekdays';
   static const options = 'options';
-  static const or = 'or';
   static const orOperatorDescription = 'orOperatorDescription';
   static const order = 'order';
   static const orderAtCharge = 'orderAtCharge';
-  static const orderBricksExplanation = 'orderBricksExplanation';
   static const organizationData = 'organizationData';
   static const organizationId = 'organizationId';
-  static const origin = 'origin';
   static const original = 'original';
   static const otherColors = 'otherColors';
   static const others = 'others';
@@ -3128,10 +3112,8 @@ abstract class LocaleKeys {
   static const overlapInMinutesDescription = 'overlapInMinutesDescription';
   static const overwriteGlobalSettings = 'overwriteGlobalSettings';
   static const overwriteSingleFile = 'overwriteSingleFile';
-  static const overwriteSingleImage = 'overwriteSingleImage';
   static const owner = 'owner';
   static const ownerExplanation = 'ownerExplanation';
-  static const page = 'page';
   static const pageList = 'pageList';
   static const pageNotFound = 'pageNotFound';
   static const parameter = 'parameter';
@@ -3144,6 +3126,7 @@ abstract class LocaleKeys {
   static const parseListDescription = 'parseListDescription';
   static const partner = 'partner';
   static const partnerId = 'partnerId';
+  static const partnerLicense = 'partnerLicense';
   static const passedChecks = 'passedChecks';
   static const password = 'password';
   static const passwordRequirements = 'passwordRequirements';
@@ -3153,29 +3136,28 @@ abstract class LocaleKeys {
   static const paths = 'paths';
   static const pause = 'pause';
   static const pauseMin = 'pauseMin';
-  static const pauseWorkflow = 'pauseWorkflow';
   static const paused = 'paused';
   static const payDirectly = 'payDirectly';
   static const payInvoice = 'payInvoice';
-  static const paymentProfile = 'paymentProfile';
   static const pdfMerge = 'pdfMerge';
   static const pdfMergeCreditUsageExplanation =
       'pdfMergeCreditUsageExplanation';
   static const pdfMergeExplanation = 'pdfMergeExplanation';
   static const pdfSettingExplanation = 'pdfSettingExplanation';
-  static const pdfs = 'pdfs';
   static const pending = 'pending';
   static const per = 'per';
-  static const permissions = 'permissions';
   static const permissionsLists = 'permissionsLists';
   static const personalData = 'personalData';
   static const phone = 'phone';
   static const phoneBrickDescription = 'phoneBrickDescription';
-  static const phoneNumber = 'phoneNumber';
   static const pipe = 'pipe';
   static const placeholderExpression = 'placeholderExpression';
   static const placeholderExpressionText = 'placeholderExpressionText';
   static const plain = 'plain';
+  static const planner = 'planner';
+  static const plannerDescription = 'plannerDescription';
+  static const plannerPreviewExplanation = 'plannerPreviewExplanation';
+  static const plannerSetSettings = 'plannerSetSettings';
   static const pleaseConnect = 'pleaseConnect';
   static const pleaseEnableLocationAccessForApp =
       'pleaseEnableLocationAccessForApp';
@@ -3191,11 +3173,7 @@ abstract class LocaleKeys {
       'pleaseSaveDesignModeChangesBeforeShareList';
   static const pleaseSaveDesignModeChangesStopShareList =
       'pleaseSaveDesignModeChangesStopShareList';
-  static const pleaseSaveDesignModeChangesToContinue =
-      'pleaseSaveDesignModeChangesToContinue';
   static const plusDescription = 'plusDescription';
-  static const portalDomains = 'portalDomains';
-  static const portalDomainsExplanation = 'portalDomainsExplanation';
   static const position = 'position';
   static const possibleColors = 'possibleColors';
   static const postalCode = 'postalCode';
@@ -3207,6 +3185,7 @@ abstract class LocaleKeys {
   static const powerShellSync = 'powerShellSync';
   static const powerShellSyncApiKeyName = 'powerShellSyncApiKeyName';
   static const powerUserMinimum = 'powerUserMinimum';
+  static const preTaxHint = 'preTaxHint';
   static const preallocateQuantity = 'preallocateQuantity';
   static const prefill = 'prefill';
   static const prefillExplanation = 'prefillExplanation';
@@ -3233,22 +3212,23 @@ abstract class LocaleKeys {
   static const process = 'process';
   static const processImages = 'processImages';
   static const processItem = 'processItem';
-  static const processingRecord = 'processingRecord';
   static const processingRecords = 'processingRecords';
   static const processingRecordsProgress = 'processingRecordsProgress';
   static const processingSelectedRecords = 'processingSelectedRecords';
   static const prodWorkspace = 'prodWorkspace';
-  static const productName = 'productName';
   static const profile = 'profile';
   static const profilePicture = 'profilePicture';
+  static const progress = 'progress';
+  static const progressBrickDescription = 'progressBrickDescription';
+  static const progressBrickNoValues = 'progressBrickNoValues';
+  static const progressNoStyleError = 'progressNoStyleError';
+  static const progressStartSmallerThanEnd = 'progressStartSmallerThanEnd';
   static const prohibitMultipleSubmit = 'prohibitMultipleSubmit';
   static const prohibitZoom = 'prohibitZoom';
   static const projectManagement = 'projectManagement';
-  static const prominent = 'prominent';
   static const prompt = 'prompt';
   static const prompting = 'prompting';
   static const promptingExplanation = 'promptingExplanation';
-  static const provider = 'provider';
   static const publicTiles = 'publicTiles';
   static const publishSolution = 'publishSolution';
   static const publishSolutionDialog = 'publishSolutionDialog';
@@ -3263,13 +3243,12 @@ abstract class LocaleKeys {
   static const quantity = 'quantity';
   static const quantityBrick = 'quantityBrick';
   static const questionsAboutLicenses = 'questionsAboutLicenses';
-  static const questionsAboutLicenses2 = 'questionsAboutLicenses2';
-  static const questionsToSolutions = 'questionsToSolutions';
   static const quickAccess = 'quickAccess';
   static const quickFilter = 'quickFilter';
+  static const quickLinks = 'quickLinks';
+  static const radial = 'radial';
   static const randomNumberDescription = 'randomNumberDescription';
   static const randomStringDescription = 'randomStringDescription';
-  static const range = 'range';
   static const rangeDescription = 'rangeDescription';
   static const read = 'read';
   static const readAccess = 'readAccess';
@@ -3295,7 +3274,6 @@ abstract class LocaleKeys {
   static const recipientEmail = 'recipientEmail';
   static const recipientEmails = 'recipientEmails';
   static const recipientNames = 'recipientNames';
-  static const recommendedSolutions = 'recommendedSolutions';
   static const record = 'record';
   static const recordAlreadyExists = 'recordAlreadyExists';
   static const recordContainsDuplicatedSecondaryKeyValue =
@@ -3312,7 +3290,6 @@ abstract class LocaleKeys {
       'recordListItemDividerLimitReached';
   static const recordListReference = 'recordListReference';
   static const recordLocked = 'recordLocked';
-  static const recordNoLongerExists = 'recordNoLongerExists';
   static const recordNotFound = 'recordNotFound';
   static const recordNotFound404 = 'recordNotFound404';
   static const recordPickerAutoAppliedIcon = 'recordPickerAutoAppliedIcon';
@@ -3325,23 +3302,21 @@ abstract class LocaleKeys {
   static const recordSpecWithTemplateIdNotFound =
       'recordSpecWithTemplateIdNotFound';
   static const recordTitle = 'recordTitle';
-  static const recordWithConditionTrigger = 'recordWithConditionTrigger';
+  static const recordVariableDescription = 'recordVariableDescription';
   static const records = 'records';
   static const recordsAre = 'recordsAre';
   static const rectangle = 'rectangle';
   static const recurrence = 'recurrence';
   static const recurrenceInterval = 'recurrenceInterval';
-  static const recurrenceOnDays = 'recurrenceOnDays';
+  static const reduceView = 'reduceView';
   static const reference = 'reference';
   static const referenceBrick = 'referenceBrick';
   static const referral = 'referral';
-  static const refresh = 'refresh';
   static const refused = 'refused';
   static const regenerate = 'regenerate';
   static const regenerateCalendarSecretKeyDescription =
       'regenerateCalendarSecretKeyDescription';
   static const regenerateSecretKey = 'regenerateSecretKey';
-  static const region = 'region';
   static const register = 'register';
   static const registerNow = 'registerNow';
   static const registration = 'registration';
@@ -3349,10 +3324,12 @@ abstract class LocaleKeys {
   static const relationships = 'relationships';
   static const releaseBrickDescription = 'releaseBrickDescription';
   static const remainingTileColors = 'remainingTileColors';
-  static const remainingTime = 'remainingTime';
   static const remove = 'remove';
+  static const removeBillingAdminFromBillingAdminList =
+      'removeBillingAdminFromBillingAdminList';
   static const removeDuplicatesDescription = 'removeDuplicatesDescription';
   static const removeEntry = 'removeEntry';
+  static const removeFollowingRoles = 'removeFollowingRoles';
   static const removeFromListDescription = 'removeFromListDescription';
   static const removeMember = 'removeMember';
   static const removeProfilePicture = 'removeProfilePicture';
@@ -3364,12 +3341,17 @@ abstract class LocaleKeys {
   static const removedInvalidRoleConfigurations =
       'removedInvalidRoleConfigurations';
   static const removingUser = 'removingUser';
-  static const reorderComponent = 'reorderComponent';
   static const repairNowBtn = 'repairNowBtn';
   static const repeatWorkflow = 'repeatWorkflow';
   static const replaceDescription = 'replaceDescription';
   static const replaceRegExpDescription = 'replaceRegExpDescription';
   static const replaceRoute = 'replaceRoute';
+  static const replyAll = 'replyAll';
+  static const replyContent = 'replyContent';
+  static const replyToEmail = 'replyToEmail';
+  static const replyToEmailStepDescription = 'replyToEmailStepDescription';
+  static const reportError = 'reportError';
+  static const reportProblemToSupport = 'reportProblemToSupport';
   static const request = 'request';
   static const requestApproval = 'requestApproval';
   static const requestApprovalAgain = 'requestApprovalAgain';
@@ -3388,7 +3370,6 @@ abstract class LocaleKeys {
   static const resetCredentials = 'resetCredentials';
   static const resetNow = 'resetNow';
   static const resetPassword = 'resetPassword';
-  static const resetSelection = 'resetSelection';
   static const resetStatus = 'resetStatus';
   static const resource = 'resource';
   static const resourceAllocation = 'resourceAllocation';
@@ -3408,8 +3389,10 @@ abstract class LocaleKeys {
   static const responseFormat = 'responseFormat';
   static const responseFormatExplanation = 'responseFormatExplanation';
   static const responseSchema = 'responseSchema';
+  static const results = 'results';
   static const resumeOnError = 'resumeOnError';
   static const resumeWorkflow = 'resumeWorkflow';
+  static const retry = 'retry';
   static const returnType = 'returnType';
   static const returnValue = 'returnValue';
   static const returnValueStepCanOnlyBeUsedOnce =
@@ -3422,15 +3405,19 @@ abstract class LocaleKeys {
   static const richTextHint = 'richTextHint';
   static const richTextHintDescription = 'richTextHintDescription';
   static const richTextHintLineCountExceeded = 'richTextHintLineCountExceeded';
-  static const rightBox = 'rightBox';
   static const rocketImageSemanticLabel = 'rocketImageSemanticLabel';
   static const role = 'role';
+  static const roleClashBannerIntro = 'roleClashBannerIntro';
+  static const roleClashBannerTitle = 'roleClashBannerTitle';
+  static const roleClashIndicatorTooltip = 'roleClashIndicatorTooltip';
+  static const roleClashPairHeader = 'roleClashPairHeader';
+  static const roleClashRow = 'roleClashRow';
   static const roleExternallySynced = 'roleExternallySynced';
   static const roleExternallySyncedWarning = 'roleExternallySyncedWarning';
   static const roleIdsOrNames = 'roleIdsOrNames';
-  static const roleName = 'roleName';
   static const roleNameExample = 'roleNameExample';
   static const roleNameOrId = 'roleNameOrId';
+  static const roleNameOrIds = 'roleNameOrIds';
   static const roleNameTooLong = 'roleNameTooLong';
   static const rolePlural = 'rolePlural';
   static const roleReferenceDeleteFilter = 'roleReferenceDeleteFilter';
@@ -3453,9 +3440,7 @@ abstract class LocaleKeys {
   static const rowPlural = 'rowPlural';
   static const rowSumOver = 'rowSumOver';
   static const rowTotal = 'rowTotal';
-  static const rowWithNumber = 'rowWithNumber';
   static const rows = 'rows';
-  static const rule = 'rule';
   static const ruleWorkflows = 'ruleWorkflows';
   static const rules = 'rules';
   static const rulesDescription = 'rulesDescription';
@@ -3470,6 +3455,7 @@ abstract class LocaleKeys {
   static const salutation = 'salutation';
   static const salutationFemale = 'salutationFemale';
   static const salutationMale = 'salutationMale';
+  static const sapBusinessOne = 'sapBusinessOne';
   static const saturdayAbbreviated = 'saturdayAbbreviated';
   static const save = 'save';
   static const saveAndCopy = 'saveAndCopy';
@@ -3478,11 +3464,15 @@ abstract class LocaleKeys {
   static const saveChanges = 'saveChanges';
   static const saveFile = 'saveFile';
   static const saveFileStepDescription = 'saveFileStepDescription';
+  static const saveFileStepVariableExplanation =
+      'saveFileStepVariableExplanation';
   static const saveForAllUsers = 'saveForAllUsers';
   static const saveStripeSubscriptionItemError =
       'saveStripeSubscriptionItemError';
   static const saveToHomeScreen = 'saveToHomeScreen';
   static const saveToSentEmails = 'saveToSentEmails';
+  static const saveToSentEmailsTooltipMicrosoft =
+      'saveToSentEmailsTooltipMicrosoft';
   static const savingDrawing = 'savingDrawing';
   static const savingFiles = 'savingFiles';
   static const savingRoles = 'savingRoles';
@@ -3499,15 +3489,17 @@ abstract class LocaleKeys {
       'scannerSearchCannotBeEnabledWithoutListFullTextSearch';
   static const scannerSound = 'scannerSound';
   static const scannerStepDescription = 'scannerStepDescription';
+  static const scannerStepVariableExplanation =
+      'scannerStepVariableExplanation';
   static const scannerValue = 'scannerValue';
   static const scheduledAt = 'scheduledAt';
+  static const scheduledJobFound = 'scheduledJobFound';
   static const scheduler = 'scheduler';
   static const schedulerBrickDescription = 'schedulerBrickDescription';
   static const schedulerSetSettings = 'schedulerSetSettings';
   static const scopes = 'scopes';
   static const search = 'search';
   static const searchBricks = 'searchBricks';
-  static const searchCols = 'searchCols';
   static const searchForBricks = 'searchForBricks';
   static const searchForFormulasOrVariables = 'searchForFormulasOrVariables';
   static const searchLabel = 'searchLabel';
@@ -3518,14 +3510,12 @@ abstract class LocaleKeys {
   static const searchProvider = 'searchProvider';
   static const searchResultsFor = 'searchResultsFor';
   static const searchRole = 'searchRole';
-  static const searchRows = 'searchRows';
   static const searchRuleWorkflow = 'searchRuleWorkflow';
   static const searchSteps = 'searchSteps';
   static const searchTile = 'searchTile';
   static const searchWorkflow = 'searchWorkflow';
   static const searching = 'searching';
   static const searchingWithLabel = 'searchingWithLabel';
-  static const secondAndThirdValue = 'secondAndThirdValue';
   static const secondaryButton = 'secondaryButton';
   static const secondaryColor = 'secondaryColor';
   static const secondaryKey = 'secondaryKey';
@@ -3584,7 +3574,11 @@ abstract class LocaleKeys {
       'sendApprovalRequestStepDescription';
   static const sendAutomatically = 'sendAutomatically';
   static const sendEmail = 'sendEmail';
+  static const sendEmailStepBodyVariableExplanation =
+      'sendEmailStepBodyVariableExplanation';
   static const sendEmailStepDescription = 'sendEmailStepDescription';
+  static const sendEmailStepStatusVariableExplanation =
+      'sendEmailStepStatusVariableExplanation';
   static const sendGrid = 'sendGrid';
   static const sendImmediately = 'sendImmediately';
   static const sendInBulk = 'sendInBulk';
@@ -3624,9 +3618,12 @@ abstract class LocaleKeys {
   static const settingsMembersTooltip = 'settingsMembersTooltip';
   static const settingsNameInputHelperInfo = 'settingsNameInputHelperInfo';
   static const settingsNotificationsTooltip = 'settingsNotificationsTooltip';
+  static const settingsRecordVariableExplanation =
+      'settingsRecordVariableExplanation';
   static const settingsRolesTooltip1 = 'settingsRolesTooltip1';
   static const settingsRolesTooltip2 = 'settingsRolesTooltip2';
   static const settingsRolesTooltip3 = 'settingsRolesTooltip3';
+  static const settingsTile = 'settingsTile';
   static const settingsTileHintText = 'settingsTileHintText';
   static const share = 'share';
   static const shareInvitationLink = 'shareInvitationLink';
@@ -3636,7 +3633,6 @@ abstract class LocaleKeys {
   static const shortcutBack = 'shortcutBack';
   static const shortcutBackDescription = 'shortcutBackDescription';
   static const shortcutClose = 'shortcutClose';
-  static const shortcutCloseDescription = 'shortcutCloseDescription';
   static const shortcutDebugMode = 'shortcutDebugMode';
   static const shortcutDebugModeDescription = 'shortcutDebugModeDescription';
   static const shortcutDelete = 'shortcutDelete';
@@ -3656,7 +3652,6 @@ abstract class LocaleKeys {
   static const shortcutSwitchWorkspaceDescription =
       'shortcutSwitchWorkspaceDescription';
   static const shortcuts = 'shortcuts';
-  static const showActiveInvitationLinks = 'showActiveInvitationLinks';
   static const showAddress = 'showAddress';
   static const showAdminMenu = 'showAdminMenu';
   static const showAll = 'showAll';
@@ -3664,7 +3659,6 @@ abstract class LocaleKeys {
   static const showArrow = 'showArrow';
   static const showAsLink = 'showAsLink';
   static const showComponentsOf = 'showComponentsOf';
-  static const showComponentsOfUser = 'showComponentsOfUser';
   static const showCurrentLocationButton = 'showCurrentLocationButton';
   static const showDebugMessages = 'showDebugMessages';
   static const showDetailForSingleRecord = 'showDetailForSingleRecord';
@@ -3689,18 +3683,17 @@ abstract class LocaleKeys {
   static const showOnMap = 'showOnMap';
   static const showOnboardingChecklist = 'showOnboardingChecklist';
   static const showOnlyUnread = 'showOnlyUnread';
-  static const showPrivateMemberTiles = 'showPrivateMemberTiles';
   static const showSettings = 'showSettings';
   static const showTabs = 'showTabs';
   static const showTooltip = 'showTooltip';
   static const showTotal = 'showTotal';
+  static const showTransfers = 'showTransfers';
   static const showUnderConditions = 'showUnderConditions';
   static const showUnit = 'showUnit';
   static const showWeekday = 'showWeekday';
   static const showWorkWeek = 'showWorkWeek';
   static const showWorkflowExecution = 'showWorkflowExecution';
   static const showWorkflows = 'showWorkflows';
-  static const sideColor = 'sideColor';
   static const signIn = 'signIn';
   static const signInVia = 'signInVia';
   static const signOut = 'signOut';
@@ -3710,7 +3703,6 @@ abstract class LocaleKeys {
   static const signerName = 'signerName';
   static const signingOut = 'signingOut';
   static const singleFile = 'singleFile';
-  static const singleImage = 'singleImage';
   static const singleQuote = 'singleQuote';
   static const singleSelect = 'singleSelect';
   static const size = 'size';
@@ -3726,7 +3718,6 @@ abstract class LocaleKeys {
   static const slotRight = 'slotRight';
   static const small = 'small';
   static const smallestPossibleNumber = 'smallestPossibleNumber';
-  static const smtp = 'smtp';
   static const smtpEmail = 'smtpEmail';
   static const smtpImap = 'smtpImap';
   static const smtpServerHost = 'smtpServerHost';
@@ -3735,17 +3726,12 @@ abstract class LocaleKeys {
   static const solutionArchive = 'solutionArchive';
   static const solutionAssigned = 'solutionAssigned';
   static const solutionBrickExplanation = 'solutionBrickExplanation';
-  static const solutionBuildArchiveNotFound = 'solutionBuildArchiveNotFound';
   static const solutionBuildCorruptedArchiveFound =
       'solutionBuildCorruptedArchiveFound';
   static const solutionBuildDescription = 'solutionBuildDescription';
   static const solutionBuildHealthCheckFailed =
       'solutionBuildHealthCheckFailed';
-  static const solutionBuildInvalid = 'solutionBuildInvalid';
-  static const solutionBuildInvalidTip = 'solutionBuildInvalidTip';
   static const solutionBuildNotFound = 'solutionBuildNotFound';
-  static const solutionBuildNotFoundTip = 'solutionBuildNotFoundTip';
-  static const solutionBuildRequiresUpdate = 'solutionBuildRequiresUpdate';
   static const solutionBuildVersion = 'solutionBuildVersion';
   static const solutionBuildVersionPlaceholder =
       'solutionBuildVersionPlaceholder';
@@ -3765,7 +3751,6 @@ abstract class LocaleKeys {
   static const solutionCustomization = 'solutionCustomization';
   static const solutionCustomizationDisabled = 'solutionCustomizationDisabled';
   static const solutionDependencies = 'solutionDependencies';
-  static const solutionDescription = 'solutionDescription';
   static const solutionDescriptionTooLong = 'solutionDescriptionTooLong';
   static const solutionDownloads = 'solutionDownloads';
   static const solutionExplanation = 'solutionExplanation';
@@ -3784,7 +3769,6 @@ abstract class LocaleKeys {
   static const solutionName = 'solutionName';
   static const solutionNamePlaceholder = 'solutionNamePlaceholder';
   static const solutionNameTooLong = 'solutionNameTooLong';
-  static const solutionNew = 'solutionNew';
   static const solutionNewVersion = 'solutionNewVersion';
   static const solutionNotFound = 'solutionNotFound';
   static const solutionPublisher = 'solutionPublisher';
@@ -3803,12 +3787,7 @@ abstract class LocaleKeys {
   static const solutionTileExplanation = 'solutionTileExplanation';
   static const solutionTimeTriggeredWorkflowsWarning =
       'solutionTimeTriggeredWorkflowsWarning';
-  static const solutionUpToDate = 'solutionUpToDate';
-  static const solutionUpdate = 'solutionUpdate';
   static const solutionUpdateAvailable = 'solutionUpdateAvailable';
-  static const solutionUpdateDisclaimer = 'solutionUpdateDisclaimer';
-  static const solutionUpdateDisclaimerMessage =
-      'solutionUpdateDisclaimerMessage';
   static const solutionUpdateFailed = 'solutionUpdateFailed';
   static const solutionUpload = 'solutionUpload';
   static const solutionVersion = 'solutionVersion';
@@ -3819,11 +3798,11 @@ abstract class LocaleKeys {
       'solutionWorkspaceInstallationDisabled';
   static const solutionWorkspaceInstallationDisabledTip =
       'solutionWorkspaceInstallationDisabledTip';
-  static const solutions = 'solutions';
   static const solutionsBeta = 'solutionsBeta';
-  static const solutionsEmptyInfo = 'solutionsEmptyInfo';
   static const somebody = 'somebody';
   static const somethingWentWrong = 'somethingWentWrong';
+  static const source = 'source';
+  static const sourceTab = 'sourceTab';
   static const space = 'space';
   static const specific = 'specific';
   static const splitDescription = 'splitDescription';
@@ -3857,6 +3836,7 @@ abstract class LocaleKeys {
   static const startedAt = 'startedAt';
   static const startedWorkflow = 'startedWorkflow';
   static const state = 'state';
+  static const staticIpAddress = 'staticIpAddress';
   static const status = 'status';
   static const statusBrickDescription = 'statusBrickDescription';
   static const statusBrickLinkExplanation = 'statusBrickLinkExplanation';
@@ -3868,10 +3848,10 @@ abstract class LocaleKeys {
   static const statusLabelCannotBeEmpty = 'statusLabelCannotBeEmpty';
   static const statusSetSettings = 'statusSetSettings';
   static const statusSettings = 'statusSettings';
-  static const statusWithNumber = 'statusWithNumber';
   static const stepCreditUsageFree = 'stepCreditUsageFree';
   static const stepCreditUsageGetEmails = 'stepCreditUsageGetEmails';
   static const stepCreditUsageIterateRecords = 'stepCreditUsageIterateRecords';
+  static const stepCreditUsageReplyToEmail = 'stepCreditUsageReplyToEmail';
   static const stepCreditUsageRuleWorkflow = 'stepCreditUsageRuleWorkflow';
   static const stepCreditUsageRunAction = 'stepCreditUsageRunAction';
   static const stepCreditUsageSaveFile = 'stepCreditUsageSaveFile';
@@ -3880,26 +3860,30 @@ abstract class LocaleKeys {
   static const stepCreditUsageUploadFileToCloudStorage =
       'stepCreditUsageUploadFileToCloudStorage';
   static const stepCreditUsageWebRequest = 'stepCreditUsageWebRequest';
-  static const stepMessageIterate = 'stepMessageIterate';
   static const stepNotImplemented = 'stepNotImplemented';
   static const stopSharing = 'stopSharing';
   static const store = 'store';
-  static const storeInstallOnlyForBetaUsers = 'storeInstallOnlyForBetaUsers';
-  static const storeInstallOnlyForBetaUsersTip =
-      'storeInstallOnlyForBetaUsersTip';
+  static const streak = 'streak';
+  static const streakBrickDescription = 'streakBrickDescription';
+  static const streakBrickNoValues = 'streakBrickNoValues';
+  static const streakCounter = 'streakCounter';
+  static const streakGoal = 'streakGoal';
   static const street = 'street';
+  static const stripe = 'stripe';
   static const stripeAccountCreationFailed = 'stripeAccountCreationFailed';
   static const stripeAccountCreationFailedDescription =
       'stripeAccountCreationFailedDescription';
   static const stripeCreateCheckoutSessionFailed =
       'stripeCreateCheckoutSessionFailed';
+  static const stripeCreateCheckoutSessionFailedDetails =
+      'stripeCreateCheckoutSessionFailedDetails';
   static const stripeError = 'stripeError';
+  static const stripeInvalidHost = 'stripeInvalidHost';
   static const stripeInvoicePreviewFailed = 'stripeInvoicePreviewFailed';
   static const stripeInvoicePreviewFailedDetails =
       'stripeInvoicePreviewFailedDetails';
   static const stripeLaunchBillingAccountSessionFailed =
       'stripeLaunchBillingAccountSessionFailed';
-  static const stripeNotActivated = 'stripeNotActivated';
   static const stripeNotSupported = 'stripeNotSupported';
   static const stripePortal = 'stripePortal';
   static const strokeWidth = 'strokeWidth';
@@ -3912,12 +3896,11 @@ abstract class LocaleKeys {
   static const subscribeToNewsletter = 'subscribeToNewsletter';
   static const subscriptionUpdateSuccessful = 'subscriptionUpdateSuccessful';
   static const substringDescription = 'substringDescription';
-  static const subtractDaysDatesDescription = 'subtractDaysDatesDescription';
   static const subtractDaysDescription = 'subtractDaysDescription';
-  static const subtractHoursDatesDescription = 'subtractHoursDatesDescription';
   static const subtractHoursDescription = 'subtractHoursDescription';
   static const subtractMinutesDescription = 'subtractMinutesDescription';
   static const subtractMonthsDescription = 'subtractMonthsDescription';
+  static const subtractSecondsDescription = 'subtractSecondsDescription';
   static const subtractWeeksDescription = 'subtractWeeksDescription';
   static const subtractYearsDescription = 'subtractYearsDescription';
   static const success = 'success';
@@ -3929,10 +3912,10 @@ abstract class LocaleKeys {
   static const sumOverBrick = 'sumOverBrick';
   static const sumUpQuantity = 'sumUpQuantity';
   static const sundayAbbreviated = 'sundayAbbreviated';
+  static const supportMailHtml = 'supportMailHtml';
   static const supportedLanguages = 'supportedLanguages';
   static const switchBrickDescription = 'switchBrickDescription';
   static const switchCompactView = 'switchCompactView';
-  static const switchFlowTypeWarning = 'switchFlowTypeWarning';
   static const switchStepDescription = 'switchStepDescription';
   static const switchToExpandedView = 'switchToExpandedView';
   static const switch_ = 'switch_';
@@ -3970,7 +3953,6 @@ abstract class LocaleKeys {
   static const taxExempt = 'taxExempt';
   static const taxId = 'taxId';
   static const taxInformation = 'taxInformation';
-  static const taxStatus = 'taxStatus';
   static const taxed = 'taxed';
   static const teamMember = 'teamMember';
   static const techName = 'techName';
@@ -3983,22 +3965,17 @@ abstract class LocaleKeys {
   static const technicalNameHelperInfo = 'technicalNameHelperInfo';
   static const technicalNameNotSet = 'technicalNameNotSet';
   static const technicalNameTooLong = 'technicalNameTooLong';
-  static const template = 'template';
-  static const templateConstructionSite = 'templateConstructionSite';
-  static const templateHr = 'templateHr';
   static const templateId = 'templateId';
   static const templateIdMappingNotFound = 'templateIdMappingNotFound';
-  static const templateInventory = 'templateInventory';
-  static const templateOnboarding = 'templateOnboarding';
-  static const templateOriginalDemo = 'templateOriginalDemo';
-  static const templateTimeRecording = 'templateTimeRecording';
-  static const templateToDo = 'templateToDo';
+  static const temporaryInvoiceReference = 'temporaryInvoiceReference';
+  static const temporaryInvoiceReferenceHint = 'temporaryInvoiceReferenceHint';
   static const tenantId = 'tenantId';
+  static const testConversion = 'testConversion';
   static const testUser = 'testUser';
   static const testUserInWorkspace = 'testUserInWorkspace';
   static const testWorkspace = 'testWorkspace';
   static const text = 'text';
-  static const textAcceptingOnlySingleChars = 'textAcceptingOnlySingleChars';
+  static const textEncoding = 'textEncoding';
   static const textExpression = 'textExpression';
   static const textExpressionBrickDescription =
       'textExpressionBrickDescription';
@@ -4007,13 +3984,10 @@ abstract class LocaleKeys {
   static const textFieldOrTextExpressionBrick =
       'textFieldOrTextExpressionBrick';
   static const textForPrintout = 'textForPrintout';
-  static const textJsonFormat = 'textJsonFormat';
   static const textLengthDescription = 'textLengthDescription';
-  static const textOptional = 'textOptional';
   static const thankYou = 'thankYou';
   static const thankYouForFeedback = 'thankYouForFeedback';
   static const theme = 'theme';
-  static const thirdValue = 'thirdValue';
   static const thousandsSeparator = 'thousandsSeparator';
   static const throwErrorAndCancelWorkflow = 'throwErrorAndCancelWorkflow';
   static const thursdayAbbreviated = 'thursdayAbbreviated';
@@ -4021,9 +3995,9 @@ abstract class LocaleKeys {
   static const tileAppearance = 'tileAppearance';
   static const tileBasicSettingsExplanation = 'tileBasicSettingsExplanation';
   static const tileColor = 'tileColor';
+  static const tileId = 'tileId';
   static const tileInfo = 'tileInfo';
   static const tileNotFoundById = 'tileNotFoundById';
-  static const tileNotFoundForRecordSpec = 'tileNotFoundForRecordSpec';
   static const tilePreview = 'tilePreview';
   static const tileReferenceInFilter = 'tileReferenceInFilter';
   static const tileReferenceInRolePermissions =
@@ -4052,6 +4026,7 @@ abstract class LocaleKeys {
   static const tilesInFolder = 'tilesInFolder';
   static const time = 'time';
   static const timeSpan = 'timeSpan';
+  static const timeSpanBrick = 'timeSpanBrick';
   static const timeSpanBrickDescription = 'timeSpanBrickDescription';
   static const timeTrigger = 'timeTrigger';
   static const timeWithBreak = 'timeWithBreak';
@@ -4071,7 +4046,6 @@ abstract class LocaleKeys {
   static const to = 'to';
   static const toCharCodeDescription = 'toCharCodeDescription';
   static const toDateTime = 'toDateTime';
-  static const toDo = 'toDo';
   static const toDoMailBodyLower = 'toDoMailBodyLower';
   static const toDoMailBodyUpper = 'toDoMailBodyUpper';
   static const toDoMailBodyUpperNoOwnToDos = 'toDoMailBodyUpperNoOwnToDos';
@@ -4097,7 +4071,6 @@ abstract class LocaleKeys {
   static const toNumberDescription = 'toNumberDescription';
   static const toOnboardingWorkspace = 'toOnboardingWorkspace';
   static const toRadixStringDescription = 'toRadixStringDescription';
-  static const toSolutionSettings = 'toSolutionSettings';
   static const toTextDescription = 'toTextDescription';
   static const toUnivelop = 'toUnivelop';
   static const toUpperCaseDescription = 'toUpperCaseDescription';
@@ -4134,6 +4107,7 @@ abstract class LocaleKeys {
   static const totalsAndCapacitiesExplanation =
       'totalsAndCapacitiesExplanation';
   static const transferAddress = 'transferAddress';
+  static const transferBillingAccount = 'transferBillingAccount';
   static const transferFrom = 'transferFrom';
   static const transferFromSync = 'transferFromSync';
   static const transferIn = 'transferIn';
@@ -4151,20 +4125,33 @@ abstract class LocaleKeys {
   static const transfers = 'transfers';
   static const trigger = 'trigger';
   static const triggerAfterSave = 'triggerAfterSave';
+  static const triggerBaseFilterExplanation = 'triggerBaseFilterExplanation';
   static const triggerBeforeSave = 'triggerBeforeSave';
   static const triggerBeforeSaveDescription = 'triggerBeforeSaveDescription';
   static const triggerBeforeSaveFilterExplanation =
       'triggerBeforeSaveFilterExplanation';
   static const triggerBeforeSaveFilterWarning =
       'triggerBeforeSaveFilterWarning';
+  static const triggerBrickValuesChanged = 'triggerBrickValuesChanged';
+  static const triggerBrickValuesChangedDescription =
+      'triggerBrickValuesChangedDescription';
+  static const triggerBrickValuesChangedFilterExplanation =
+      'triggerBrickValuesChangedFilterExplanation';
   static const triggerConditionsReference = 'triggerConditionsReference';
   static const triggerDescription = 'triggerDescription';
+  static const triggerMaxDepthExceeded = 'triggerMaxDepthExceeded';
+  static const triggerMoreInfo = 'triggerMoreInfo';
+  static const triggerMoreInfoDescription = 'triggerMoreInfoDescription';
   static const triggerOpenRecord = 'triggerOpenRecord';
   static const triggerOpenRecordDescription = 'triggerOpenRecordDescription';
   static const triggerOpenRecordList = 'triggerOpenRecordList';
   static const triggerOpenRecordListDescription =
       'triggerOpenRecordListDescription';
+  static const triggerRuleWorkflowFailed = 'triggerRuleWorkflowFailed';
   static const triggerType = 'triggerType';
+  static const triggerWatchedBrickValues = 'triggerWatchedBrickValues';
+  static const triggerWatchedBrickValuesExplanation =
+      'triggerWatchedBrickValuesExplanation';
   static const trimDescription = 'trimDescription';
   static const tryNow = 'tryNow';
   static const tryParseDateDescription = 'tryParseDateDescription';
@@ -4177,10 +4164,8 @@ abstract class LocaleKeys {
   static const uniCademy = 'uniCademy';
   static const uninstall = 'uninstall';
   static const unit = 'unit';
-  static const unitPrice = 'unitPrice';
   static const univelopAvatar = 'univelopAvatar';
   static const univelopOpenAi = 'univelopOpenAi';
-  static const univelopUser = 'univelopUser';
   static const unknown = 'unknown';
   static const unknownActionType = 'unknownActionType';
   static const unknownContent = 'unknownContent';
@@ -4199,15 +4184,14 @@ abstract class LocaleKeys {
   static const unlockingRecord = 'unlockingRecord';
   static const unsupportedLink = 'unsupportedLink';
   static const until = 'until';
-  static const updateAccountInformation = 'updateAccountInformation';
   static const updateAllSolutions = 'updateAllSolutions';
   static const updateApp = 'updateApp';
   static const updateAppExplanationMobile = 'updateAppExplanationMobile';
   static const updateAppExplanationWeb = 'updateAppExplanationWeb';
-  static const updateBillingAccountFailed = 'updateBillingAccountFailed';
   static const updateBillingCycle = 'updateBillingCycle';
   static const updateBillingCycleFailed = 'updateBillingCycleFailed';
   static const updateTileIndicators = 'updateTileIndicators';
+  static const updatingBillingInfo = 'updatingBillingInfo';
   static const uploadFileToCloudStorage = 'uploadFileToCloudStorage';
   static const uploadFileToCloudStorageConflictBehaviorFail =
       'uploadFileToCloudStorageConflictBehaviorFail';
@@ -4229,12 +4213,15 @@ abstract class LocaleKeys {
   static const urlForButton = 'urlForButton';
   static const useFilters = 'useFilters';
   static const useSharedMailbox = 'useSharedMailbox';
-  static const useTemplate = 'useTemplate';
+  static const useStaticIp = 'useStaticIp';
+  static const useStaticIpExplanation = 'useStaticIpExplanation';
+  static const useStaticIpForcedByIntegration =
+      'useStaticIpForcedByIntegration';
   static const useUnivelopOpenAiIntegration = 'useUnivelopOpenAiIntegration';
   static const used = 'used';
   static const usefulInformation = 'usefulInformation';
   static const user = 'user';
-  static const userEmail = 'userEmail';
+  static const userDefinedVariable = 'userDefinedVariable';
   static const userGreeting = 'userGreeting';
   static const userGroups = 'userGroups';
   static const userId = 'userId';
@@ -4250,7 +4237,6 @@ abstract class LocaleKeys {
   static const userPickerBrickDescription = 'userPickerBrickDescription';
   static const userPickerForApproval = 'userPickerForApproval';
   static const userRole = 'userRole';
-  static const userRoleID = 'userRoleID';
   static const userUntaggedInRecordBody = 'userUntaggedInRecordBody';
   static const userUntaggedInRecordTitle = 'userUntaggedInRecordTitle';
   static const userWithoutPermissions = 'userWithoutPermissions';
@@ -4283,7 +4269,6 @@ abstract class LocaleKeys {
       'validationPasswordConfirmationWrong';
   static const validationPasswordDigit = 'validationPasswordDigit';
   static const validationPasswordLength = 'validationPasswordLength';
-  static const validationPasswordLengthOld = 'validationPasswordLengthOld';
   static const validationPasswordLowerCase = 'validationPasswordLowerCase';
   static const validationPasswordSpecialCharacter =
       'validationPasswordSpecialCharacter';
@@ -4305,7 +4290,9 @@ abstract class LocaleKeys {
   static const valueMustNotBeEmpty = 'valueMustNotBeEmpty';
   static const valueQrBarcode = 'valueQrBarcode';
   static const valueQrBarcodeExplanation = 'valueQrBarcodeExplanation';
+  static const values = 'values';
   static const variable = 'variable';
+  static const variableSettingsRecordOrigin = 'variableSettingsRecordOrigin';
   static const variableType = 'variableType';
   static const variables = 'variables';
   static const version = 'version';
@@ -4318,11 +4305,9 @@ abstract class LocaleKeys {
   static const visibilityActionButtonExplanation =
       'visibilityActionButtonExplanation';
   static const visibilityExplanation = 'visibilityExplanation';
-  static const visibilityForRoles = 'visibilityForRoles';
   static const visibilityOfRoles = 'visibilityOfRoles';
   static const visibilityOfRolesOnTile = 'visibilityOfRolesOnTile';
   static const visualization = 'visualization';
-  static const voiceForm = 'voiceForm';
   static const waitFor = 'waitFor';
   static const waitForApproval = 'waitForApproval';
   static const waitForApprovalStepDescription =
@@ -4338,7 +4323,6 @@ abstract class LocaleKeys {
   static const waitingForRun = 'waitingForRun';
   static const waitingStepDescription = 'waitingStepDescription';
   static const waitingTime = 'waitingTime';
-  static const wantToOpenLink = 'wantToOpenLink';
   static const warning = 'warning';
   static const warningAuthenticationInClientWorkflows =
       'warningAuthenticationInClientWorkflows';
@@ -4346,6 +4330,7 @@ abstract class LocaleKeys {
   static const warningMessage = 'warningMessage';
   static const warningStepDoesNotSupportDryRun =
       'warningStepDoesNotSupportDryRun';
+  static const warningUpdateSubscriptions = 'warningUpdateSubscriptions';
   static const warnings = 'warnings';
   static const watermarkExplanation = 'watermarkExplanation';
   static const watermarks = 'watermarks';
@@ -4354,22 +4339,34 @@ abstract class LocaleKeys {
   static const webHookButtonBrickDescription = 'webHookButtonBrickDescription';
   static const webLink = 'webLink';
   static const webRequest = 'webRequest';
+  static const webRequestStepBodyVariableExplanation =
+      'webRequestStepBodyVariableExplanation';
   static const webRequestStepDescription = 'webRequestStepDescription';
+  static const webRequestStepHeadersVariableExplanation =
+      'webRequestStepHeadersVariableExplanation';
+  static const webRequestStepStatusVariableExplanation =
+      'webRequestStepStatusVariableExplanation';
   static const webResponseFormat = 'webResponseFormat';
   static const webTileNameExample = 'webTileNameExample';
   static const webhook = 'webhook';
+  static const webhookPayloadValueDescription =
+      'webhookPayloadValueDescription';
+  static const webhookPayloadVariableDescription =
+      'webhookPayloadVariableDescription';
   static const webhookSettings = 'webhookSettings';
   static const webhookStepDescription = 'webhookStepDescription';
   static const webhookStepExplanation = 'webhookStepExplanation';
+  static const webhookStepPayloadSubValueDescription =
+      'webhookStepPayloadSubValueDescription';
   static const webhookUrl = 'webhookUrl';
   static const website = 'website';
   static const wednesdayAbbreviated = 'wednesdayAbbreviated';
   static const week = 'week';
-  static const weekText = 'weekText';
   static const weekly = 'weekly';
   static const welcomeSemanticLabel = 'welcomeSemanticLabel';
   static const white = 'white';
   static const width = 'width';
+  static const windows1252 = 'windows1252';
   static const withManualNumbers = 'withManualNumbers';
   static const withdrawRequest = 'withdrawRequest';
   static const withoutTitle = 'withoutTitle';
@@ -4390,7 +4387,6 @@ abstract class LocaleKeys {
   static const workflowSteps = 'workflowSteps';
   static const workflowTechNameExplanation = 'workflowTechNameExplanation';
   static const workflows = 'workflows';
-  static const workspace = 'workspace';
   static const workspaceAiBuilderIntegrationReference =
       'workspaceAiBuilderIntegrationReference';
   static const workspaceBanner = 'workspaceBanner';
@@ -4413,6 +4409,10 @@ abstract class LocaleKeys {
   static const writeFilter = 'writeFilter';
   static const writePermissions = 'writePermissions';
   static const xmlBrickDescription = 'xmlBrickDescription';
+  static const xmlInput = 'xmlInput';
+  static const xmlToJson = 'xmlToJson';
+  static const xmlToJsonStepDescription = 'xmlToJsonStepDescription';
+  static const xpathFilter = 'xpathFilter';
   static const year = 'year';
   static const yearly = 'yearly';
   static const yearlyNominative = 'yearlyNominative';

--- a/lib/src/generated/locale_keys.g.dart
+++ b/lib/src/generated/locale_keys.g.dart
@@ -616,6 +616,8 @@ abstract class LocaleKeys {
   static const bccNames = 'bccNames';
   static const beganAt = 'beganAt';
   static const behavior = 'behavior';
+  static const belongsToLinkedRecordConfirmDescription =
+      'belongsToLinkedRecordConfirmDescription';
   static const belongsToLinkedRecordLabel = 'belongsToLinkedRecordLabel';
   static const beta = 'beta';
   static const betaTester = 'betaTester';
@@ -647,9 +649,13 @@ abstract class LocaleKeys {
   static const billingAddress = 'billingAddress';
   static const billingAdmin = 'billingAdmin';
   static const billingCycle = 'billingCycle';
+  static const billingLinkedCustomerDisclaimer =
+      'billingLinkedCustomerDisclaimer';
   static const billingOptions = 'billingOptions';
   static const billingOptionsInfoText = 'billingOptionsInfoText';
   static const billingOwner = 'billingOwner';
+  static const billingPartnerAccountDisclaimer =
+      'billingPartnerAccountDisclaimer';
   static const billingType = 'billingType';
   static const binary = 'binary';
   static const binaryToBase64Description = 'binaryToBase64Description';
@@ -969,6 +975,7 @@ abstract class LocaleKeys {
   static const connectBillingAccount = 'connectBillingAccount';
   static const connectBillingAccount2 = 'connectBillingAccount2';
   static const connectBillingAccountInfo = 'connectBillingAccountInfo';
+  static const connectPartnerAccount = 'connectPartnerAccount';
   static const connectedBillingAccounts = 'connectedBillingAccounts';
   static const connection = 'connection';
   static const connectionTestFailed = 'connectionTestFailed';
@@ -1031,6 +1038,8 @@ abstract class LocaleKeys {
   static const createRecordIfNoneFound = 'createRecordIfNoneFound';
   static const createRecordStepDescription = 'createRecordStepDescription';
   static const createRuleWorkflow = 'createRuleWorkflow';
+  static const createSubBillingAccount = 'createSubBillingAccount';
+  static const createSubBillingAccountInfo = 'createSubBillingAccountInfo';
   static const createSubscription = 'createSubscription';
   static const createSubscriptionInfo = 'createSubscriptionInfo';
   static const createUser = 'createUser';
@@ -1328,6 +1337,46 @@ abstract class LocaleKeys {
   static const embeddedInBrowser = 'embeddedInBrowser';
   static const embeddedList = 'embeddedList';
   static const embeddedMobile = 'embeddedMobile';
+  static const embeddedRecordBrick = 'embeddedRecordBrick';
+  static const embeddedRecordBrickBelongsToRequired =
+      'embeddedRecordBrickBelongsToRequired';
+  static const embeddedRecordBrickChildNotLinked =
+      'embeddedRecordBrickChildNotLinked';
+  static const embeddedRecordBrickDescription =
+      'embeddedRecordBrickDescription';
+  static const embeddedRecordBrickHideDetailButton =
+      'embeddedRecordBrickHideDetailButton';
+  static const embeddedRecordBrickInvalidRelation =
+      'embeddedRecordBrickInvalidRelation';
+  static const embeddedRecordBrickLinkToLocked =
+      'embeddedRecordBrickLinkToLocked';
+  static const embeddedRecordBrickListPickerInfo =
+      'embeddedRecordBrickListPickerInfo';
+  static const embeddedRecordBrickModeDynamic =
+      'embeddedRecordBrickModeDynamic';
+  static const embeddedRecordBrickModeDynamicDescription =
+      'embeddedRecordBrickModeDynamicDescription';
+  static const embeddedRecordBrickModeFixed = 'embeddedRecordBrickModeFixed';
+  static const embeddedRecordBrickModeFixedDescription =
+      'embeddedRecordBrickModeFixedDescription';
+  static const embeddedRecordBrickNestingNotAllowed =
+      'embeddedRecordBrickNestingNotAllowed';
+  static const embeddedRecordBrickNoOptionsAvailable =
+      'embeddedRecordBrickNoOptionsAvailable';
+  static const embeddedRecordBrickOptionInUse =
+      'embeddedRecordBrickOptionInUse';
+  static const embeddedRecordBrickPermissionIndependent =
+      'embeddedRecordBrickPermissionIndependent';
+  static const embeddedRecordBrickPermissionIndependentDescription =
+      'embeddedRecordBrickPermissionIndependentDescription';
+  static const embeddedRecordBrickPermissionInherit =
+      'embeddedRecordBrickPermissionInherit';
+  static const embeddedRecordBrickPermissionInheritDescription =
+      'embeddedRecordBrickPermissionInheritDescription';
+  static const embeddedRecordBrickPermissionMode =
+      'embeddedRecordBrickPermissionMode';
+  static const embeddedRecordBrickSelectType = 'embeddedRecordBrickSelectType';
+  static const embeddedRecordBrickType = 'embeddedRecordBrickType';
   static const embeddingNotPossible = 'embeddingNotPossible';
   static const emptyDescription = 'emptyDescription';
   static const emptyTextField = 'emptyTextField';
@@ -1526,6 +1575,12 @@ abstract class LocaleKeys {
   static const exceptionEmailOnFlowError = 'exceptionEmailOnFlowError';
   static const exceptionEmailsCouldNotBeFetched =
       'exceptionEmailsCouldNotBeFetched';
+  static const exceptionEmbeddedRecordBrickActionAlreadyLinked =
+      'exceptionEmbeddedRecordBrickActionAlreadyLinked';
+  static const exceptionEmbeddedRecordBrickActionOnlyInFixedMode =
+      'exceptionEmbeddedRecordBrickActionOnlyInFixedMode';
+  static const exceptionEmbeddedRecordBrickRecordIdRequiresSpec =
+      'exceptionEmbeddedRecordBrickRecordIdRequiresSpec';
   static const exceptionEmptyEmailContent = 'exceptionEmptyEmailContent';
   static const exceptionEmptyEmailSubject = 'exceptionEmptyEmailSubject';
   static const exceptionEmptyFileContent = 'exceptionEmptyFileContent';
@@ -1762,6 +1817,8 @@ abstract class LocaleKeys {
   static const exceptionRecordNotFoundById = 'exceptionRecordNotFoundById';
   static const exceptionRecordNotFoundCannotImport =
       'exceptionRecordNotFoundCannotImport';
+  static const exceptionRecordPickerHasBelongsToRecordSelected =
+      'exceptionRecordPickerHasBelongsToRecordSelected';
   static const exceptionRecordSpecNotFound = 'exceptionRecordSpecNotFound';
   static const exceptionRecordTitleSemicolon = 'exceptionRecordTitleSemicolon';
   static const exceptionRoleExternallySynced = 'exceptionRoleExternallySynced';
@@ -2531,6 +2588,9 @@ abstract class LocaleKeys {
   static const invoiceBilling = 'invoiceBilling';
   static const invoiceInfo1 = 'invoiceInfo1';
   static const invoiceInfo2 = 'invoiceInfo2';
+  static const invoiceReference = 'invoiceReference';
+  static const invoiceReferenceInputHelperText =
+      'invoiceReferenceInputHelperText';
   static const invoiceScreenTitle = 'invoiceScreenTitle';
   static const invoiceTaxConfirmationMessage = 'invoiceTaxConfirmationMessage';
   static const invoiceTaxConfirmationTitle = 'invoiceTaxConfirmationTitle';
@@ -2841,6 +2901,7 @@ abstract class LocaleKeys {
   static const name = 'name';
   static const nameDefaultPath = 'nameDefaultPath';
   static const nameOfOrganization = 'nameOfOrganization';
+  static const nameOfSubBillingAccount = 'nameOfSubBillingAccount';
   static const namePathWithNumber = 'namePathWithNumber';
   static const names = 'names';
   static const navigateToHomescreen = 'navigateToHomescreen';
@@ -3555,6 +3616,7 @@ abstract class LocaleKeys {
   static const selectList = 'selectList';
   static const selectMember = 'selectMember';
   static const selectOAuthMethods = 'selectOAuthMethods';
+  static const selectPartnerBillingAccount = 'selectPartnerBillingAccount';
   static const selectRecords = 'selectRecords';
   static const selectRole = 'selectRole';
   static const selectStatus = 'selectStatus';
@@ -3889,6 +3951,11 @@ abstract class LocaleKeys {
   static const strokeWidth = 'strokeWidth';
   static const structure = 'structure';
   static const style = 'style';
+  static const subBillingAccountCreated = 'subBillingAccountCreated';
+  static const subBillingAccountCreatedPreheader =
+      'subBillingAccountCreatedPreheader';
+  static const subBillingAccountCreationMailBody =
+      'subBillingAccountCreationMailBody';
   static const subheadingBrickDescription = 'subheadingBrickDescription';
   static const subject = 'subject';
   static const submitButtonLabel = 'submitButtonLabel';
@@ -4109,9 +4176,11 @@ abstract class LocaleKeys {
   static const transferAddress = 'transferAddress';
   static const transferBillingAccount = 'transferBillingAccount';
   static const transferFrom = 'transferFrom';
+  static const transferFromReference = 'transferFromReference';
   static const transferFromSync = 'transferFromSync';
   static const transferIn = 'transferIn';
   static const transferOrigin = 'transferOrigin';
+  static const transferOriginReference = 'transferOriginReference';
   static const transferOut = 'transferOut';
   static const transferRightsFromStatus = 'transferRightsFromStatus';
   static const transferValues = 'transferValues';
@@ -4301,6 +4370,7 @@ abstract class LocaleKeys {
   static const veryLikely = 'veryLikely';
   static const verySmall = 'verySmall';
   static const veryUnlikely = 'veryUnlikely';
+  static const viewBillingAccount = 'viewBillingAccount';
   static const visibility = 'visibility';
   static const visibilityActionButtonExplanation =
       'visibilityActionButtonExplanation';

--- a/lib/src/util/yust_file_handler.dart
+++ b/lib/src/util/yust_file_handler.dart
@@ -275,7 +275,7 @@ class YustFileHandler {
         String filePath;
         if (yustFile.cached) {
           filePath = yustFile.devicePath!;
-        // ignore: deprecated_member_use
+          // ignore: deprecated_member_use
         } else if (yustFile.url == null) {
           throw YustException(LocaleKeys.exceptionFileNotFound.tr());
         } else {
@@ -299,6 +299,49 @@ class YustFileHandler {
         await _launchBrowser(yustFile);
       }
       await EasyLoading.dismiss();
+    } catch (e) {
+      await EasyLoading.dismiss();
+      await YustUi.alertService.showAlert(
+        LocaleKeys.oops.tr(),
+        LocaleKeys.alertCannotOpenFileWithError.tr(
+          namedArgs: {'error': e.toString()},
+        ),
+      );
+    }
+  }
+
+  Future<void> showFileInDefaultApp(
+    BuildContext context,
+    YustFile yustFile,
+  ) async {
+    if (kIsWeb) {
+      await YustUi.fileHelpers.downloadAndLaunchYustFile(
+        context: context,
+        file: yustFile,
+      );
+      return;
+    }
+    await EasyLoading.show(status: LocaleKeys.loadingFile.tr());
+    try {
+      String filePath;
+      if (yustFile.cached) {
+        filePath = yustFile.devicePath!;
+        // ignore: deprecated_member_use
+      } else if (yustFile.url == null) {
+        throw YustException(LocaleKeys.exceptionFileNotFound.tr());
+      } else {
+        final fileName = Platform.isIOS
+            ? YustFileHelpers.sanitizeFileName(yustFile.name!)
+            : yustFile.name;
+        filePath = '${await _getDirectory(yustFile)}$fileName';
+        // ignore: deprecated_member_use
+        await Dio().download(yustFile.url!, filePath);
+      }
+      await EasyLoading.dismiss();
+      var result = await OpenFilex.open(filePath, useIosDefaultApp: true);
+      if (result.type != ResultType.done) {
+        await _launchBrowser(yustFile);
+      }
     } catch (e) {
       await EasyLoading.dismiss();
       await YustUi.alertService.showAlert(

--- a/lib/src/util/yust_file_handler.dart
+++ b/lib/src/util/yust_file_handler.dart
@@ -359,6 +359,13 @@ class YustFileHandler {
     }
   }
 
+  /// Opens the share sheet (mobile) or triggers a file download (web).
+  Future<void> shareFile(BuildContext context, YustFile yustFile) =>
+      YustUi.fileHelpers.downloadAndLaunchYustFile(
+        context: context,
+        file: yustFile,
+      );
+
   List<YustFile> yustFilesFromJson(
     List<Map<String, String?>> jsonFiles,
     String storageFolderPath,

--- a/lib/src/util/yust_file_handler.dart
+++ b/lib/src/util/yust_file_handler.dart
@@ -310,6 +310,12 @@ class YustFileHandler {
     }
   }
 
+  /// Opens the file in the user's default app instead of the built-in preview.
+  ///
+  /// On iOS 26+, uses [UIApplication.shared.open(fileURL)] which respects the
+  /// user's default app preference. Falls back to Quick Look on older iOS.
+  /// On Android, behaves the same as [showFile] (ACTION_VIEW).
+  /// On web, falls back to [downloadAndLaunchYustFile] (file download).
   Future<void> showFileInDefaultApp(
     BuildContext context,
     YustFile yustFile,

--- a/lib/src/widgets/yust_file_picker.dart
+++ b/lib/src/widgets/yust_file_picker.dart
@@ -268,12 +268,7 @@ class YustFilePickerState
             case YustFileTapMode.defaultApp:
               fileHandler.showFileInDefaultApp(context, file);
             case YustFileTapMode.share:
-              unawaited(
-                YustUi.fileHelpers.downloadAndLaunchYustFile(
-                  context: context,
-                  file: file,
-                ),
-              );
+              unawaited(fileHandler.shareFile(context, file));
           }
         }
       },

--- a/lib/src/widgets/yust_file_picker.dart
+++ b/lib/src/widgets/yust_file_picker.dart
@@ -11,6 +11,7 @@ import '../generated/locale_keys.g.dart';
 import '../yust_ui.dart';
 import 'yust_file_picker_base.dart';
 import 'yust_file_list_view.dart';
+import 'yust_file_tap_mode.dart';
 
 /// A widget that allows the user to pick files from their device.
 class YustFilePicker extends YustFilePickerBase<YustFile> {
@@ -45,6 +46,7 @@ class YustFilePicker extends YustFilePickerBase<YustFile> {
     super.previewCount = YustFilePickerBase.defaultPreviewCount,
     super.thumbnails = false,
     super.linkedDocStoresFilesAsMap = false,
+    super.tapMode,
     this.showModifiedAt = false,
     this.allowedExtensions,
     this.maximumFileSizeInKiB,
@@ -68,6 +70,7 @@ class YustFilePicker extends YustFilePickerBase<YustFile> {
     super.overwriteSingleFile = false,
     super.thumbnails = false,
     super.linkedDocStoresFilesAsMap = false,
+    super.tapMode,
     this.showModifiedAt = false,
     this.allowedExtensions,
     this.maximumFileSizeInKiB,
@@ -259,7 +262,19 @@ class YustFilePickerState
         }
 
         if (!isBroken) {
-          fileHandler.showFile(context, file);
+          switch (widget.tapMode) {
+            case YustFileTapMode.preview:
+              fileHandler.showFile(context, file);
+            case YustFileTapMode.defaultApp:
+              fileHandler.showFileInDefaultApp(context, file);
+            case YustFileTapMode.share:
+              unawaited(
+                YustUi.fileHelpers.downloadAndLaunchYustFile(
+                  context: context,
+                  file: file,
+                ),
+              );
+          }
         }
       },
       contentPadding: const EdgeInsets.symmetric(
@@ -278,20 +293,25 @@ class YustFilePickerState
     ],
   );
 
-  Widget _buildDownloadButton(YustFile file) => Builder(
-    builder: (buttonContext) {
-      return IconButton(
-        icon: (kIsWeb) ? const Icon(Icons.download) : const Icon(Icons.share),
-        color: Theme.of(buttonContext).primaryColor,
-        onPressed: () => unawaited(
-          YustUi.fileHelpers.downloadAndLaunchYustFile(
-            context: buttonContext,
-            file: file,
+  Widget _buildDownloadButton(YustFile file) {
+    if (widget.tapMode == YustFileTapMode.share) {
+      return const SizedBox.shrink();
+    }
+    return Builder(
+      builder: (buttonContext) {
+        return IconButton(
+          icon: (kIsWeb) ? const Icon(Icons.download) : const Icon(Icons.share),
+          color: Theme.of(buttonContext).primaryColor,
+          onPressed: () => unawaited(
+            YustUi.fileHelpers.downloadAndLaunchYustFile(
+              context: buttonContext,
+              file: file,
+            ),
           ),
-        ),
-      );
-    },
-  );
+        );
+      },
+    );
+  }
 
   Widget _buildFileRenameButton(YustFile file) {
     if (!enabled) {

--- a/lib/src/widgets/yust_file_picker_base.dart
+++ b/lib/src/widgets/yust_file_picker_base.dart
@@ -18,6 +18,7 @@ import 'yust_file_picker.dart';
 import 'yust_image_picker.dart';
 import 'yust_file_list_view.dart';
 import 'yust_file_grid_view.dart';
+import 'yust_file_tap_mode.dart';
 
 /// Base class for file pickers.
 ///
@@ -97,6 +98,9 @@ abstract class YustFilePickerBase<T extends YustFile> extends StatefulWidget {
   /// This is needed for the offline upload of files.
   final bool linkedDocStoresFilesAsMap;
 
+  /// Controls what happens when a file is tapped.
+  final YustFileTapMode tapMode;
+
   const YustFilePickerBase({
     super.key,
     this.label,
@@ -120,6 +124,7 @@ abstract class YustFilePickerBase<T extends YustFile> extends StatefulWidget {
     this.previewCount = defaultPreviewCount,
     this.thumbnails = false,
     this.linkedDocStoresFilesAsMap = false,
+    this.tapMode = YustFileTapMode.preview,
   });
 
   /// Default number of items to show initially and load more on demand.

--- a/lib/src/widgets/yust_file_tap_mode.dart
+++ b/lib/src/widgets/yust_file_tap_mode.dart
@@ -1,0 +1,13 @@
+/// Controls what happens when a file is tapped in a [YustFilePicker].
+enum YustFileTapMode {
+  /// Opens the file preview (Quick Look on iOS, system viewer on Android,
+  /// browser tab on web).
+  preview,
+
+  /// Opens the file in the default app. On iOS 26+ uses the system default app
+  /// preference, falling back to preview on older versions.
+  defaultApp,
+
+  /// Shows the share sheet (mobile) or triggers a file download (web).
+  share,
+}

--- a/lib/yust_ui.dart
+++ b/lib/yust_ui.dart
@@ -19,6 +19,7 @@ export 'src/widgets/yust_doc_builder.dart';
 export 'src/widgets/yust_docs_builder.dart';
 export 'src/widgets/yust_file_picker.dart';
 export 'src/widgets/yust_file_picker_base.dart';
+export 'src/widgets/yust_file_tap_mode.dart';
 export 'src/widgets/yust_file_grid_view.dart';
 export 'src/widgets/yust_file_list_view.dart';
 export 'src/widgets/yust_focus_handler.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
     open_filex:
         git:
             url: https://github.com/univelop/open_filex.git
-            ref: feat/use-ios-default-app
+            ref: master
     path_provider: ^2.1.5
     photo_view: ^0.15.0
     share_plus: ^11.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,10 @@ dependencies:
     image: ^4.5.2
     intl: ^0.20.2
     mask_text_input_formatter: ^2.9.0
-    open_filex: ^4.7.0
+    open_filex:
+        git:
+            url: https://github.com/univelop/open_filex.git
+            ref: feat/use-ios-default-app
     path_provider: ^2.1.5
     photo_view: ^0.15.0
     share_plus: ^11.1.0


### PR DESCRIPTION
## Summary
- Adds `YustFileTapMode` enum with three modes: `preview`, `defaultApp`, `share`
- Adds `tapMode` parameter to `YustFilePickerBase` and `YustFilePicker`
- Adds `showFileInDefaultApp()` to `YustFileHandler` using forked open_filex with iOS 26 `UIApplication.shared.open(fileURL)` support
- Hides share/download button when `tapMode == share` (redundant with tap action)
- Points open_filex dependency to univelop fork with `useIosDefaultApp` flag

## Dependencies
- Requires [univelop/open_filex#feat/use-ios-default-app](https://github.com/univelop/open_filex/tree/feat/use-ios-default-app)

## Test plan
- [ ] Verify `preview` mode works as before (Quick Look on iOS, browser tab on web)
- [ ] Verify `defaultApp` mode opens in default app on iOS 26+
- [ ] Verify `share` mode shows share sheet on mobile, download on web
- [ ] Verify share button is hidden when tap mode is `share`

🤖 Generated with [Claude Code](https://claude.com/claude-code)