### PR TITLE
Release V3.32.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.32.9 - 2026-08-25
+
+- Bump `yust` to 3.33.5
+
 ## 3.32.8 - 2026-07-28
 
 - Add favorite support to `YustFilePicker`, `YustImagePicker` and the image screen (mark files/images as favorites, incl. read-only display)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yust_ui
 description: Awesome UI widgets for yust.
-version: 3.32.8
+version: 3.32.9
 homepage: https://github.com/univelop/yust_ui
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
     flutter:
         sdk: flutter
-    yust: ^3.33.4
+    yust: ^3.33.5
     cached_network_image: ^3.4.1
     cloud_firestore: ^6.0.0
     collection: ^1.19.1
@@ -57,7 +57,3 @@ dependency_overrides:
         git:
             url: https://github.com/univelop/keyboard_name.git
             ref: master
-    yust:
-        git:
-            url: https://github.com/univelop/yust.git
-            ref: 7657-favourites-for-files-and-images


### PR DESCRIPTION
Release commit for yust_ui 3.32.9.

- Bump `yust` to `^3.33.5`
- Bump version to 3.32.9 + CHANGELOG entry
- Remove the stale `dependency_overrides` entry pointing `yust` at the `7657-favourites-for-files-and-images` git branch. That override was added during the #7657 work and accidentally left in at Release V3.32.8 — every release before that had no `yust` override. Left in place it would silently resolve `yust` from git instead of the published version, making the dependency bump untested.

Depends on yust 3.33.5 being published first (univelop/yust#426).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtkjXq92yjUP9SmBw3snML